### PR TITLE
Add TLS configuration support to secret client

### DIFF
--- a/pkg/providers/vault/config.go
+++ b/pkg/providers/vault/config.go
@@ -12,7 +12,7 @@
  * the License.
  *******************************************************************************/
 
-// http defines structs that will be used frequently by clients which utilize HTTP transport.
+// vault defines structs that will be used frequently by clients which utilize HTTP transport.
 package vault
 
 import "fmt"
@@ -24,6 +24,7 @@ type SecretConfig struct {
 	Path           string
 	Protocol       string
 	Provider       string
+	RootCaCert     string
 	Authentication AuthenticationInfo
 }
 

--- a/pkg/providers/vault/errors.go
+++ b/pkg/providers/vault/errors.go
@@ -1,0 +1,13 @@
+package vault
+
+import "fmt"
+
+// ErrCaRootCert error when the provided CA Root certificate is invalid.
+type ErrCaRootCert struct {
+	path        string
+	description string
+}
+
+func (e ErrCaRootCert) Error() string {
+	return fmt.Sprintf("Unable to use the certificate '%s': %s", e.path, e.description)
+}

--- a/pkg/providers/vault/secret_manager_test.go
+++ b/pkg/providers/vault/secret_manager_test.go
@@ -77,14 +77,16 @@ func (immc *InMemoryMockCaller) Do(req *http.Request) (*http.Response, error) {
 func TestNewSecretClient(t *testing.T) {
 	cfgHttp := SecretConfig{Host: "localhost", Port: 8080, Provider: HTTPProvider}
 	cfgNoop := SecretConfig{Host: "localhost", Port: 8080, Provider: "mqtt"}
+	cfgInvalidCertPath := SecretConfig{Host: "localhost", Port: 8080, Provider: HTTPProvider, RootCaCert: "/non-existent-directory/rootCa.crt"}
 
 	tests := []struct {
 		name      string
 		cfg       SecretConfig
 		expectErr bool
 	}{
-		{"newHttp", cfgHttp, false},
-		{"newNoop", cfgNoop, true},
+		{"NewSecretClient HTTP configuration", cfgHttp, false},
+		{"NewSecretClient  unsupported provider", cfgNoop, true},
+		{"NewSecretClient invalid CA root certificate path", cfgInvalidCertPath, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fix #7

Add functionality to allow the underlying HTTP client to use a Root CA
cert so that the HTTP client can communicate via HTTPS with a
self-signed cert.

Add new 'ErrCaRootCert' error for communicating cert errors to the
caller.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>