### PR TITLE
Update SecretClient provider ID to be explicit

### DIFF
--- a/pkg/providers/vault/constants.go
+++ b/pkg/providers/vault/constants.go
@@ -1,7 +1,9 @@
 package vault
 
 const (
-	HTTPProvider  = "http"
+	// VaultProvider indicates the use of Hashicorp's Vault secret manager as a secret store provider.
 	VaultProvider = "vault"
-	VaultToken    = "X-Vault-Token"
+
+	// VaultToken identifies the access token used for authentication when communicating with Vault.
+	VaultToken = "X-Vault-Token"
 )

--- a/pkg/providers/vault/secret_manager.go
+++ b/pkg/providers/vault/secret_manager.go
@@ -33,7 +33,7 @@ type HttpSecretStoreManager struct {
 // NewSecretClient constructs a SecretClient which communicates with a storage mechanism via HTTP
 func NewSecretClient(config SecretConfig) (pkg.SecretClient, error) {
 	switch config.Provider {
-	case HTTPProvider:
+	case VaultProvider:
 		httpClient, err := createHttpClient(config)
 		if err != nil {
 			return pkg.SecretClient{}, err

--- a/pkg/providers/vault/secret_manager_test.go
+++ b/pkg/providers/vault/secret_manager_test.go
@@ -78,9 +78,9 @@ func (immc *InMemoryMockCaller) Do(req *http.Request) (*http.Response, error) {
 }
 
 func TestNewSecretClient(t *testing.T) {
-	cfgHttp := SecretConfig{Host: "localhost", Port: 8080, Provider: HTTPProvider}
+	cfgHttp := SecretConfig{Host: "localhost", Port: 8080, Provider: VaultProvider}
 	cfgNoop := SecretConfig{Host: "localhost", Port: 8080, Provider: "mqtt"}
-	cfgInvalidCertPath := SecretConfig{Host: "localhost", Port: 8080, Provider: HTTPProvider, RootCaCert: "/non-existent-directory/rootCa.crt"}
+	cfgInvalidCertPath := SecretConfig{Host: "localhost", Port: 8080, Provider: VaultProvider, RootCaCert: "/non-existent-directory/rootCa.crt"}
 
 	tests := []struct {
 		name      string


### PR DESCRIPTION
Update the SecretClient constructor to use a more explicit identifier
for the Vault provider. Previously, the provider used was 'http'. From
the callers perspective this is not completely deterministic as to what
secret store abstraction is being used. It is more clear to expect the
caller to provide a 'provider' which indicates which abstraction they
would like to use and have the 'protocol' indicate the transport
mechanism which the provider should use. A good example  of this would
be if we support different versions of the Vault API, we could have
different providers which expect different response structures but the
communication protocol could be the same and the user could use either
depending on their situation.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>