### PR TITLE
Add Vault Namespace support within SecretClient

### DIFF
--- a/pkg/providers/vault/config.go
+++ b/pkg/providers/vault/config.go
@@ -24,6 +24,7 @@ type SecretConfig struct {
 	Path           string
 	Protocol       string
 	Provider       string
+	Namespace      string
 	RootCaCert     string
 	Authentication AuthenticationInfo
 }

--- a/pkg/providers/vault/constants.go
+++ b/pkg/providers/vault/constants.go
@@ -1,7 +1,8 @@
 package vault
 
 const (
-	HTTPProvider  = "http"
-	VaultProvider = "vault"
-	VaultToken    = "X-Vault-Token"
+	HTTPProvider    = "http"
+	VaultProvider   = "vault"
+	VaultToken      = "X-Vault-Token"
+	NamespaceHeader = "X-Vault-Namespace"
 )

--- a/pkg/providers/vault/secret_manager.go
+++ b/pkg/providers/vault/secret_manager.go
@@ -85,6 +85,11 @@ func (c HttpSecretStoreManager) getAllKeys() (map[string]interface{}, error) {
 	}
 
 	req.Header.Set(c.HttpConfig.Authentication.AuthType, c.HttpConfig.Authentication.AuthToken)
+
+	if c.HttpConfig.Namespace != "" {
+		req.Header.Set(NamespaceHeader, c.HttpConfig.Namespace)
+	}
+
 	resp, err := c.HttpCaller.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fix #17

Update the SecretConfig and Vault SecretClient to support Vault's notion
of Namespaces. The SecretConfig has been updated to contain a
configuration property which allow users to specify the Namespace to
operate under when interacting with the Vault SecretStore. The
SecretClient has been updated to provide the Namespace information in
the appropriate header when interacting with the Vault HTTP API

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>