### PR TITLE
Create Listener for getting secret updates

### DIFF
--- a/pkg/listener/poll.go
+++ b/pkg/listener/poll.go
@@ -1,0 +1,155 @@
+/********************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package listener
+
+import (
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/edgexfoundry/go-mod-secrets/pkg"
+)
+
+// InMemoryCacheListener retrieves secrets from a secret store and provides updates based on a specified interval.
+type InMemoryCacheListener struct {
+	// secretClient retrieves secrets from a secret store.
+	secretClient pkg.SecretClient
+	// keys contains the keys for which to provide updates.
+	keys []string
+	// updaterChan communicates updates to the keys/
+	updaterChan chan map[string]string
+	// errorChan communicates errors from the background process to the caller.
+	errorChan chan error
+	// stopChan signals when the background process should begin shutting down.
+	stopChan chan struct{}
+	// backoffPattern contains a series of intervals to use when invoking the secret client.
+	backoffPattern []int
+	// cache stores the last known secrets
+	cache map[string]string // Protect with mutex?
+	// isRunning holds the state of the listener
+	isRunning bool
+	// timerFunc abstracts the logic used to create a timer. This is most useful for testing when validating the backoff pattern logic.
+	timerFunc func(duration time.Duration) *time.Timer
+	// runningStateMutex protects the 'isRunning' state of the listener from race conditions
+	runningStateMutex *sync.Mutex
+	// cacheMutex protects the 'cache' from race conditions.
+	cacheMutex *sync.Mutex
+}
+
+// NewInMemoryCacheListener creates a new InMemoryCacheListener
+func NewInMemoryCacheListener(client pkg.SecretClient, updateChan chan map[string]string, errorChan chan error, backoffPattern []int, keys []string) InMemoryCacheListener {
+	return InMemoryCacheListener{
+		secretClient:      client,
+		keys:              keys,
+		updaterChan:       updateChan,
+		errorChan:         errorChan,
+		stopChan:          make(chan struct{}),
+		backoffPattern:    backoffPattern,
+		isRunning:         false,
+		timerFunc:         time.NewTimer,
+		runningStateMutex: &sync.Mutex{},
+		cacheMutex:        &sync.Mutex{},
+	}
+}
+
+// GetKeys retrieves the secrets via the secret client
+func (c *InMemoryCacheListener) GetKeys() (map[string]string, error) {
+	c.cacheMutex.Lock()
+	defer c.cacheMutex.Unlock()
+
+	secrets, err := c.secretClient.GetSecrets(c.keys...)
+	if err != nil {
+		return nil, err
+	}
+
+	c.cache = secrets
+
+	return c.cache, nil
+}
+
+// Start invokes the background process which will provide updates.
+func (c *InMemoryCacheListener) Start() error {
+	c.runningStateMutex.Lock()
+	defer c.runningStateMutex.Unlock()
+
+	if c.isRunning {
+		return ErrInvalidListenerState{message: "This listener has already started"}
+	}
+
+	c.isRunning = true
+	go c.update()
+
+	return nil
+}
+
+// Stop terminates the background process which provides updates.
+func (c *InMemoryCacheListener) Stop() error {
+	c.runningStateMutex.Lock()
+	defer c.runningStateMutex.Unlock()
+
+	if !c.isRunning {
+		return ErrInvalidListenerState{message: "This listener has not been started"}
+	}
+
+	c.stopChan <- struct{}{}
+
+	return nil
+}
+
+// update provides the logic for providing updates.
+// This function is intended to be executed in a go-routine.
+// **NOTE** The use of the 'stopChan' must be done in a thread safe manner since the result of receiving data from that
+// channel will result in the 'InMemoryCacheListener.isRunning' to change state.
+func (c *InMemoryCacheListener) update() {
+	errorCount := 0
+	for {
+		backoffIndex := errorCount
+		if backoffIndex > len(c.backoffPattern)-1 {
+			backoffIndex = len(c.backoffPattern) - 1
+		}
+
+		timer := c.timerFunc(time.Duration(c.backoffPattern[backoffIndex]) * time.Second)
+		select {
+		case <-timer.C:
+			{
+				secrets, err := c.secretClient.GetSecrets(c.keys...)
+				if err != nil {
+					c.errorChan <- err
+					errorCount++
+					continue
+				}
+
+				errorCount = 0
+				if c.cache == nil || !reflect.DeepEqual(secrets, c.cache) {
+					c.cacheMutex.Lock()
+					c.cache = secrets
+					c.cacheMutex.Unlock()
+					c.updaterChan <- secrets
+				}
+
+			}
+		case <-c.stopChan:
+			c.runningStateMutex.Lock()
+			if !c.isRunning {
+				c.errorChan <- ErrInvalidListenerState{message: "This listener has not been started"}
+			}
+			c.isRunning = false
+			timer.Stop()
+			c.runningStateMutex.Unlock()
+			return
+		}
+
+	}
+}

--- a/pkg/listener/poll_test.go
+++ b/pkg/listener/poll_test.go
@@ -1,0 +1,271 @@
+/********************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package listener
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/edgexfoundry/go-mod-secrets/pkg"
+)
+
+var Secrets = map[string]string{
+	"one":   "uno",
+	"two":   "dos",
+	"three": "tres",
+}
+
+var TestClient = pkg.SecretClient{
+	Manager: MockSecretStoreManager{
+		secretStore: &Secrets,
+	}}
+
+type MockSecretStoreManager struct {
+	secretStore *map[string]string
+}
+
+func (mssm MockSecretStoreManager) GetValues(keys ...string) (map[string]string, error) {
+	var notFound []string
+	secrets := make(map[string]string)
+	for _, key := range keys {
+		ss := *mssm.secretStore
+		s, ok := ss[key]
+		if !ok {
+			notFound = append(notFound, key)
+			continue
+		}
+		secrets[key] = s
+	}
+
+	if len(notFound) > 0 {
+		return nil, pkg.NewErrSecretsNotFound(notFound)
+	}
+
+	return secrets, nil
+}
+
+func TestGetKeys(t *testing.T) {
+	c := NewInMemoryCacheListener(TestClient, make(chan map[string]string), make(chan error, 10), []int{0}, []string{"one", "two"})
+	s, err := c.GetKeys()
+	if err != nil {
+		t.Errorf("Unexpected error ocurred: %s", err.Error())
+		return
+	}
+
+	expected := map[string]string{
+		"one": "uno",
+		"two": "dos",
+	}
+
+	if !reflect.DeepEqual(s, expected) {
+		t.Errorf("Expected: %v, but got:%v", expected, s)
+		return
+	}
+}
+
+func TestGetKeysError(t *testing.T) {
+	c := NewInMemoryCacheListener(TestClient, make(chan map[string]string), make(chan error, 10), []int{0}, []string{"doesNotExist"})
+	_, err := c.GetKeys()
+	if err == nil {
+		t.Errorf("Expected an error")
+		return
+	}
+
+	switch err.(type) {
+	case pkg.ErrSecretsNotFound:
+		break
+	default:
+		t.Errorf("Expected error of type ErrSecretsNotFound")
+	}
+}
+
+func TestErrorPropagation(t *testing.T) {
+	errChan := make(chan error)
+	c := NewInMemoryCacheListener(TestClient, make(chan map[string]string), errChan, []int{0}, []string{"doesNotExist"})
+
+	err := c.Start()
+	if err != nil {
+		t.Errorf("Unexpected error ocurred: %s", err.Error())
+		return
+	}
+	timeout := time.NewTimer(500 * time.Millisecond)
+	select {
+	case <-errChan:
+		break
+	case <-timeout.C:
+		t.Errorf("Failed to communicate error within the given timeframe")
+	}
+}
+
+func TestStopStateCheck(t *testing.T) {
+	c := NewInMemoryCacheListener(TestClient, make(chan map[string]string), make(chan error), []int{0}, []string{"one"})
+	err := c.Stop()
+	if err == nil {
+		t.Errorf("Expected error for invalid state")
+		return
+	}
+
+	switch err.(type) {
+	case ErrInvalidListenerState:
+		break
+	default:
+		t.Errorf("Expected error of type ErrInvalidListenerState")
+	}
+}
+
+func TestStartStateCheck(t *testing.T) {
+	c := NewInMemoryCacheListener(TestClient, make(chan map[string]string), make(chan error), []int{0}, []string{"one"})
+	err := c.Start()
+	if err != nil {
+		t.Errorf("Unexpected error ocurred: %s", err.Error())
+		return
+	}
+
+	err = c.Start()
+	if err == nil {
+		t.Errorf("Expected error for invalid state")
+		return
+	}
+
+	switch err.(type) {
+	case ErrInvalidListenerState:
+		break
+	default:
+		t.Errorf("Expected error of type ErrInvalidListenerState")
+	}
+}
+
+/*
+ / Tests which are run in parallel
+*/
+
+func TestNoUpdate(t *testing.T) {
+	// Run this test in parallel with with other tests that have a timeout.
+	t.Parallel()
+
+	errChan := make(chan error)
+	updateChan := make(chan map[string]string)
+	c := NewInMemoryCacheListener(TestClient, updateChan, errChan, []int{0}, []string{"one", "two"})
+	_, err := c.GetKeys()
+	if err != nil {
+		t.Errorf("Unexpected error ocurred: %s", err.Error())
+		return
+	}
+
+	err = c.Start()
+	if err != nil {
+		t.Errorf("Unexpected error ocurred: %s", err.Error())
+		return
+	}
+	timeout := time.NewTimer(3 * time.Second)
+	select {
+	case <-updateChan:
+		t.Errorf("Expected no updates, but got one")
+	case <-errChan:
+		t.Errorf("Expected no errors, but got one")
+	case <-timeout.C:
+		break
+	}
+}
+
+func TestBackoffPattern(t *testing.T) {
+	// Run this test in parallel with with other tests that have a timeout.
+	t.Parallel()
+
+	callCount := 0
+	backoffPattern := []int{1, 2, 3}
+	numOfTries := len(backoffPattern) + 1
+
+	completeChan := make(chan struct{})
+	c := NewInMemoryCacheListener(TestClient, make(chan map[string]string), make(chan error, 10), backoffPattern, []string{"doesNotExist"})
+
+	// Warp the Timer constructor with some verification logic so we can validate that the underlying timer is being
+	// invoked with the correct intervals.
+	c.timerFunc = func(duration time.Duration) *time.Timer {
+		if callCount >= numOfTries {
+			completeChan <- struct{}{}
+		}
+
+		index := callCount
+		if index > len(backoffPattern)-1 {
+			index = len(backoffPattern) - 1
+		}
+
+		expected := time.Duration(backoffPattern[index]) * time.Second
+
+		if expected != duration {
+			t.Errorf("Expected: %v, and instead got: %v", expected, duration)
+		}
+
+		callCount++
+		return time.NewTimer(duration)
+	}
+
+	err := c.Start()
+	if err != nil {
+		t.Errorf("Unexpected error ocurred: %s", err.Error())
+		return
+	}
+
+	timeout := time.NewTimer(30 * time.Second)
+	select {
+	case <-completeChan:
+		_ = c.Stop()
+		break
+	case <-timeout.C:
+		t.Errorf("Failed to communicate error within the given timeframe")
+	}
+}
+
+// TestStateConcurrency tests the handling of the state within the listener.
+// This test concurrently start and stops the listener in an attempt to trigger a deadlock or race condition. This test
+// should be run with the '-race' option enabled to leverage the Go race detection tools.
+func TestStateConcurrency(t *testing.T) {
+	// Run this test in parallel with with other tests that may take longer to execute.
+	t.Parallel()
+
+	numOfRestarts := 1000
+	c := NewInMemoryCacheListener(TestClient, make(chan map[string]string), make(chan error), []int{0}, []string{"one"})
+
+	// Create 2 go-routines which will restart the listener concurrently to test the thread-safety of the state
+	// modifications.
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go restart(c, numOfRestarts, &wg, t)
+	wg.Add(1)
+	go restart(c, numOfRestarts, &wg, t)
+	wg.Wait()
+}
+
+// restart executes restart functionality on the listener repeatedly.
+// This is a helper function used to aid in testing the state handling functionality. This function ignores errors
+// returned by calling any start, stop, or restart function since errors are expected to be returned to the caller
+// during an invalid state issue. This is expected to run in a go-routine.
+func restart(c InMemoryCacheListener, numOfRestarts int, wg *sync.WaitGroup, t *testing.T) {
+	defer wg.Done()
+	for i := 0; i < numOfRestarts; i++ {
+		err := c.Start()
+		if err != nil {
+			continue
+		}
+
+		err = c.Stop()
+		if err != nil {
+			continue
+		}
+	}
+}

--- a/pkg/listener/types.go
+++ b/pkg/listener/types.go
@@ -1,0 +1,27 @@
+/********************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package listener
+
+import "fmt"
+
+// ErrInvalidListenerState represents errors that are related to the state of the listener.
+type ErrInvalidListenerState struct {
+	message string
+}
+
+// Error generates a message for the invalid state error.
+func (e ErrInvalidListenerState) Error() string {
+	return fmt.Sprintf("Invalid state: %s", e.message)
+}


### PR DESCRIPTION
Fix #16

Add new 'InMemoryCacheListener' which adds functionality for
pro-actively polling a secret store for updates.

Create new 'listener' package which houses different implementations for
obtaining updates from a secret store.

Add tests for new logic

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>