### PR TITLE
Remove provider configuration property

### DIFF
--- a/pkg/providers/vault/config.go
+++ b/pkg/providers/vault/config.go
@@ -23,7 +23,6 @@ type SecretConfig struct {
 	Port           int
 	Path           string
 	Protocol       string
-	Provider       string
 	Namespace      string
 	RootCaCert     string
 	Authentication AuthenticationInfo

--- a/pkg/providers/vault/constants.go
+++ b/pkg/providers/vault/constants.go
@@ -1,8 +1,6 @@
 package vault
 
 const (
-	HTTPProvider    = "http"
-	VaultProvider   = "vault"
-	VaultToken      = "X-Vault-Token"
+	// NamespaceHeader specifies the header name to use when including Namespace information in a request.
 	NamespaceHeader = "X-Vault-Namespace"
 )

--- a/pkg/providers/vault/secret_manager.go
+++ b/pkg/providers/vault/secret_manager.go
@@ -24,32 +24,26 @@ import (
 	"github.com/edgexfoundry/go-mod-secrets/pkg"
 )
 
-// HttpSecretStoreManager defines the behavior for interacting with the REST secret key/value store.
+// HttpSecretStoreManager defines the behavior for interacting with the Vault REST secret key/value store via HTTP.
 type HttpSecretStoreManager struct {
 	HttpConfig SecretConfig
 	HttpCaller Caller
 }
 
-// NewSecretClient constructs a SecretClient which communicates with a storage mechanism via HTTP
+// NewSecretClient constructs a SecretClient which communicates with Vault via HTTP
 func NewSecretClient(config SecretConfig) (pkg.SecretClient, error) {
-	switch config.Provider {
-	case HTTPProvider:
-		httpClient, err := createHttpClient(config)
-		if err != nil {
-			return pkg.SecretClient{}, err
-		}
-
-		client := pkg.SecretClient{
-			Manager: HttpSecretStoreManager{
-				HttpConfig: config,
-				HttpCaller: httpClient,
-			},
-		}
-
-		return client, nil
-	default:
-		return pkg.SecretClient{}, fmt.Errorf("unsupported provider %s provided", config.Protocol)
+	httpClient, err := createHttpClient(config)
+	if err != nil {
+		return pkg.SecretClient{}, err
 	}
+
+	return pkg.SecretClient{
+		Manager: HttpSecretStoreManager{
+			HttpConfig: config,
+			HttpCaller: httpClient,
+		},
+	}, nil
+
 }
 
 func (c HttpSecretStoreManager) GetValues(keys ...string) (map[string]string, error) {
@@ -139,5 +133,4 @@ func createHttpClient(config SecretConfig) (Caller, error) {
 			},
 		},
 	}, nil
-
 }

--- a/pkg/providers/vault/secret_manager_test.go
+++ b/pkg/providers/vault/secret_manager_test.go
@@ -83,10 +83,9 @@ func (immc *InMemoryMockCaller) Do(req *http.Request) (*http.Response, error) {
 }
 
 func TestNewSecretClient(t *testing.T) {
-	cfgHttp := SecretConfig{Host: "localhost", Port: 8080, Provider: HTTPProvider}
-	cfgNoop := SecretConfig{Host: "localhost", Port: 8080, Provider: "mqtt"}
-	cfgInvalidCertPath := SecretConfig{Host: "localhost", Port: 8080, Provider: HTTPProvider, RootCaCert: "/non-existent-directory/rootCa.crt"}
-	cfgNamespace := SecretConfig{Host: "localhost", Port: 8080, Provider: HTTPProvider, Namespace: "database"}
+	cfgHttp := SecretConfig{Host: "localhost", Port: 8080}
+	cfgInvalidCertPath := SecretConfig{Host: "localhost", Port: 8080, RootCaCert: "/non-existent-directory/rootCa.crt"}
+	cfgNamespace := SecretConfig{Host: "localhost", Port: 8080, Namespace: "database"}
 
 	tests := []struct {
 		name      string
@@ -94,7 +93,6 @@ func TestNewSecretClient(t *testing.T) {
 		expectErr bool
 	}{
 		{"NewSecretClient HTTP configuration", cfgHttp, false},
-		{"NewSecretClient  unsupported provider", cfgNoop, true},
 		{"NewSecretClient invalid CA root certificate path", cfgInvalidCertPath, true},
 		{"NewSecretClient with Namespace", cfgNamespace, false},
 	}

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -35,13 +35,7 @@ func (scnf ErrSecretsNotFound) Error() string {
 	return fmt.Sprintf("No value for the keys: [%s] exists", strings.Join(scnf.keys, ","))
 }
 
+// NewErrSecretsNotFound creates a new ErrSecretsNotFound error.
 func NewErrSecretsNotFound(keys []string) ErrSecretsNotFound {
 	return ErrSecretsNotFound{keys: keys}
-}
-
-// ErrUnsupportedValue error for unsupported data such as invalid characters or the length of key/values
-type ErrUnsupportedValue struct{}
-
-func (ErrUnsupportedValue) Error() string {
-	panic("implement me")
 }


### PR DESCRIPTION
    Fix #18
    
    Remove the SecretConfig's provider field which was previously used to
    identify the SecretClient implementation which should be use during
    creation. This is not necessary as there is currently only one provider
    for Vault and this generalization is most likely a concern for consumers
    of the go-mod-secrets module as this still would not solve the issue of
    abstracting the creation of SecretClients since there could be clients
    which live outside of this module.
    
    Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>
