### PR TITLE
Add race detection flag to Makefile for tests

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -10,6 +10,10 @@ LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2019: Intel'
 
 RUN apk add --update bash
+RUN apk --no-cache add ca-certificates wget
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
+RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.30-r0/glibc-2.30-r0.apk
+RUN apk add glibc-2.30-r0.apk
 
 WORKDIR /go/src/github.com/edgexfoundry
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
         stage('Multi-Arch Build') {
             // fan out
             parallel {
-                stage('Test amd64') {
+                stage('Test x86') {
                     agent {
                         dockerfile {
                             filename 'Dockerfile.build'

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@
 
 .PHONY: test
 
-GO=CGO_ENABLED=0 GO111MODULE=on go
+GO=CGO_ENABLED=1 GO111MODULE=on go
 
 test:
-	$(GO) test ./... -coverprofile=coverage.out
+	$(GO) test -race ./... -coverprofile=coverage.out
 	$(GO) vet ./...
 	gofmt -l .
 	[ "`gofmt -l .`" = "" ]


### PR DESCRIPTION
Fix #22

Add '-race' flag to the `go test` command so that the race detection
tools can be leveraged. Also, needed to enable CGO to be able to use
this feature.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>