### PR TITLE
Add response code checking to Vault SecretClient

### DIFF
--- a/pkg/client.go
+++ b/pkg/client.go
@@ -24,14 +24,10 @@ type SecretClient struct {
 // If the secret manager returns a nil or empty map, a SecretsNotFound error is returned.
 // If any other error is encountered by the secret manager it is bubbled up and no partial results are provided.
 func (sc SecretClient) GetSecrets(keys ...string) (map[string]string, error) {
-	value, err := sc.Manager.GetValues(keys...)
+	secrets, err := sc.Manager.GetValues(keys...)
 	if err != nil {
 		return nil, err
 	}
 
-	if value == nil || len(value) == 0 {
-		return nil, ErrSecretsNotFound{}
-	}
-
-	return value, nil
+	return secrets, nil
 }

--- a/pkg/providers/vault/secret_manager.go
+++ b/pkg/providers/vault/secret_manager.go
@@ -89,6 +89,10 @@ func (c HttpSecretStoreManager) getAllKeys() (map[string]interface{}, error) {
 		return nil, err
 	}
 
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, pkg.NewErrSecretStore(fmt.Sprintf("Received a '%d' response from the secret store", resp.StatusCode))
+	}
+
 	defer resp.Body.Close()
 	var result map[string]interface{}
 	err = json.NewDecoder(resp.Body).Decode(&result)

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -19,11 +19,18 @@ import (
 	"strings"
 )
 
-// ErrSecretStoreConn error for communication errors with the underlying storage mechanism
-type ErrSecretStoreConn struct{}
+// ErrSecretStore error for unexpected problems with the secret store.
+type ErrSecretStore struct {
+	description string
+}
 
-func (ErrSecretStoreConn) Error() string {
-	return "Unable to obtain from underlying data-store"
+func (e ErrSecretStore) Error() string {
+	return fmt.Sprintf("Unable to obtain secrets from underlying data-store: %s", e.description)
+}
+
+// NewErrSecretStore creates an ErrSecretStore error type.
+func NewErrSecretStore(description string) ErrSecretStore {
+	return ErrSecretStore{description: description}
 }
 
 // ErrSecretsNotFound error when a secret cannot be found. This aids in differentiating between empty("") values and non-existent keys


### PR DESCRIPTION
Fix #24

Add logic to check the HTTP response code received when requesting
secrets from the secret store. Previously only HTTP errors would be
treated as an error where we should be treating non 200 responses as an
error.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>