### PR TITLE
Add functionality for TLSConfig ServerName info

### DIFF
--- a/pkg/providers/vault/config.go
+++ b/pkg/providers/vault/config.go
@@ -25,6 +25,7 @@ type SecretConfig struct {
 	Protocol       string
 	Namespace      string
 	RootCaCert     string
+	ServerName     string
 	Authentication AuthenticationInfo
 }
 

--- a/pkg/providers/vault/secret_manager.go
+++ b/pkg/providers/vault/secret_manager.go
@@ -129,7 +129,8 @@ func createHttpClient(config SecretConfig) (Caller, error) {
 	return &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
-				RootCAs: caCertPool,
+				RootCAs:    caCertPool,
+				ServerName: config.ServerName,
 			},
 		},
 	}, nil


### PR DESCRIPTION
Fix #25

Add field for server name in SecretConfig and update the SecretClient
constructor to properly apply field in the underlying HTTP client.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>