### PR TITLE
pkg/provides/vault/many: allow specifying retry logic

### DIFF
--- a/pkg/providers/vault/config.go
+++ b/pkg/providers/vault/config.go
@@ -17,18 +17,21 @@ package vault
 
 import (
 	"fmt"
+	"time"
 )
 
 // SecretConfig contains configuration settings used to communicate with an HTTP based secret provider
 type SecretConfig struct {
-	Host           string
-	Port           int
-	Path           string
-	Protocol       string
-	Namespace      string
-	RootCaCertPath string
-	ServerName     string
-	Authentication AuthenticationInfo
+	Host                    string
+	Port                    int
+	Path                    string
+	Protocol                string
+	Namespace               string
+	RootCaCertPath          string
+	ServerName              string
+	Authentication          AuthenticationInfo
+	AdditionalRetryAttempts int
+	RetryWaitPeriod         time.Duration
 }
 
 // BuildURL constructs a URL which can be used to identify a HTTP based secret provider


### PR DESCRIPTION
Allow a SecretClient to be created that retries HTTP requests that are not 2XX. Note that this behavior is optional, and needs to be opt-in by the calling client.

This enables clients of go-mod-secrets to easily block waiting for their secrets to be available.

Also include a proposed implementation of "infinite" blocking by setting the AdditionalRetryAttempts to a negative number, but error out for now, so as to not complicate testing.

Finally, update the tests to check the number of calls to Do() that are made when getting secrets under various situations.

To test this change IRL, see https://github.com/edgexfoundry/docker-edgex-mongo/pull/59 and the testing instructions there.