### PR TITLE
vault/client.go: refactor retry loop to GetSecrets instead of getAllKeys

### DIFF
--- a/pkg/providers/vault/client.go
+++ b/pkg/providers/vault/client.go
@@ -11,6 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package vault
 
 import (
@@ -33,7 +34,7 @@ type Client struct {
 
 // NewSecretClient constructs a SecretClient which communicates with Vault via HTTP(S)
 func NewSecretClient(config SecretConfig) (pkg.SecretClient, error) {
-	httpClient, err := createHttpClient(config)
+	httpClient, err := createHTTPClient(config)
 	if err != nil {
 		return Client{}, err
 	}
@@ -151,10 +152,10 @@ func (c Client) getAllKeys(path string) (map[string]string, error) {
 	return secrets, nil
 }
 
-// createHttpClient creates and configures an HTTP client which can be used to communicate with the underlying
+// createHTTPClient creates and configures an HTTP client which can be used to communicate with the underlying
 // secret-store based on the SecretConfig.
 // Returns ErrCaRootCert is there is an error with the certificate.
-func createHttpClient(config SecretConfig) (Caller, error) {
+func createHTTPClient(config SecretConfig) (Caller, error) {
 
 	if config.RootCaCertPath == "" {
 		return http.DefaultClient, nil

--- a/pkg/providers/vault/client.go
+++ b/pkg/providers/vault/client.go
@@ -45,7 +45,7 @@ func NewSecretClient(config SecretConfig) (pkg.SecretClient, error) {
 
 }
 
-// GetValues retrieves the secrets at the provided path that match the specified keys.
+// GetSecrets retrieves the secrets at the provided path that match the specified keys.
 func (c Client) GetSecrets(path string, keys ...string) (map[string]string, error) {
 	data := make(map[string]string)
 	var err error

--- a/pkg/providers/vault/client_test.go
+++ b/pkg/providers/vault/client_test.go
@@ -282,7 +282,7 @@ func TestHttpSecretStoreManager_GetValue(t *testing.T) {
 			},
 		},
 		{
-			name:              "Retry 9 times, all fail",
+			name:              "Retry 9 times, all HTTP status failures",
 			retries:           9,
 			path:              TestPath,
 			keys:              []string{"one"},
@@ -297,14 +297,14 @@ func TestHttpSecretStoreManager_GetValue(t *testing.T) {
 			},
 		},
 		{
-			name:              "Retry 9 times, 1st catastrophic failure",
+			name:              "Retry 9 times, all catastrophic failure",
 			retries:           9,
 			path:              TestPath,
 			keys:              []string{"one"},
 			expectedValues:    map[string]string{"one": "uno"},
 			expectError:       true,
 			expectedErrorType: TestConnError,
-			expectedDoCallNum: 1,
+			expectedDoCallNum: 10,
 			caller: &ErrorMockCaller{
 				ReturnError: true,
 			},

--- a/pkg/providers/vault/client_test.go
+++ b/pkg/providers/vault/client_test.go
@@ -106,7 +106,7 @@ func (immc *InMemoryMockCaller) Do(req *http.Request) (*http.Response, error) {
 }
 
 func TestNewSecretClient(t *testing.T) {
-	cfgHttp := SecretConfig{Host: "localhost", Port: 8080}
+	cfgHTTP := SecretConfig{Host: "localhost", Port: 8080}
 	cfgInvalidCertPath := SecretConfig{Host: "localhost", Port: 8080, RootCaCertPath: "/non-existent-directory/rootCa.crt"}
 	cfgNamespace := SecretConfig{Host: "localhost", Port: 8080, Namespace: "database"}
 
@@ -115,7 +115,7 @@ func TestNewSecretClient(t *testing.T) {
 		cfg       SecretConfig
 		expectErr bool
 	}{
-		{"NewSecretClient HTTP configuration", cfgHttp, false},
+		{"NewSecretClient HTTP configuration", cfgHTTP, false},
 		{"NewSecretClient invalid CA root certificate path", cfgInvalidCertPath, true},
 		{"NewSecretClient with Namespace", cfgNamespace, false},
 	}

--- a/pkg/providers/vault/config.go
+++ b/pkg/providers/vault/config.go
@@ -12,7 +12,7 @@
  * the License.
  *******************************************************************************/
 
-// vault defines structs that will be used frequently by clients which utilize HTTP transport.
+// Package vault defines structs that will be used frequently by clients which utilize HTTP transport.
 package vault
 
 import (

--- a/pkg/providers/vault/interfaces.go
+++ b/pkg/providers/vault/interfaces.go
@@ -11,6 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package vault
 
 import "net/http"


### PR DESCRIPTION
This addresses feedback from @AnthonyMBonafide on PR #36.

I did _not_ refactor this to take a string and do time.Parse, but if there's a strong opinion on this I can change this as well.

Also some minor drive-by changes to make this fall in line with go-linting (though note that some things go lint complains about aren't changable without breaking APIs :crying_cat_face: see `HttpConfig` -> `HTTPConfig`)

Lastly I added some drive-by changes to the doc-comment, see how the license currently shows up in the godoc: https://godoc.org/github.com/edgexfoundry/go-mod-secrets/pkg/providers/vault.