### PR TITLE
pkg/providers/vault: change RetryWaitPeriod to string, do parsing here

### DIFF
--- a/pkg/providers/vault/client.go
+++ b/pkg/providers/vault/client.go
@@ -39,6 +39,14 @@ func NewSecretClient(config SecretConfig) (pkg.SecretClient, error) {
 		return Client{}, err
 	}
 
+	if config.RetryWaitPeriod != "" {
+		retryTimeDuration, err := time.ParseDuration(config.RetryWaitPeriod)
+		if err != nil {
+			return nil, err
+		}
+		config.retryWaitPeriodTime = retryTimeDuration
+	}
+
 	return Client{
 		HttpConfig: config,
 		HttpCaller: httpClient,
@@ -73,7 +81,7 @@ func (c Client) GetSecrets(path string, keys ...string) (map[string]string, erro
 			// TODO: this will be run again if we hit the limit, when ideally we
 			// wouldn't wait cause we hit the limit and failed, but this is in
 			// the error case, so it's low priority to fix
-			time.Sleep(c.HttpConfig.RetryWaitPeriod)
+			time.Sleep(c.HttpConfig.retryWaitPeriodTime)
 		}
 
 		// since we finished the above loop, then check if the last iteration

--- a/pkg/providers/vault/config.go
+++ b/pkg/providers/vault/config.go
@@ -31,7 +31,8 @@ type SecretConfig struct {
 	ServerName              string
 	Authentication          AuthenticationInfo
 	AdditionalRetryAttempts int
-	RetryWaitPeriod         time.Duration
+	RetryWaitPeriod         string
+	retryWaitPeriodTime     time.Duration
 }
 
 // BuildURL constructs a URL which can be used to identify a HTTP based secret provider


### PR DESCRIPTION
It is simpler for clients of go-mod-secrets to just provide a string here since in many cases the SecretConfig struct will be built verbatim from a configuration.toml file, where we don't have complex types like time.Duration (or at least a usable version of that - time.Duration serializes as an int64 in nanoseconds which is very unusable to specify in the configuration.toml).

This means we need to do the parsing of the string here if it exists and error in the case parsing fails.

Also add some tests for this functionality. A followup-PR to docker-edgex-mongo and edgex-go will be filed in short order with more testing information.

docker-edgex-mongo PR: https://github.com/edgexfoundry/docker-edgex-mongo/pull/67

See https://github.com/edgexfoundry/edgex-go/issues/2092 and https://github.com/edgexfoundry/edgex-go/pull/2087#discussion_r343742590