### PR TITLE
Add a new API to store secret

### DIFF
--- a/pkg/client.go
+++ b/pkg/client.go
@@ -25,7 +25,7 @@ type SecretClient interface {
 	GetSecrets(path string, keys ...string) (map[string]string, error)
 
 	// StoreSecrets stores the secrets to a secret store.
-	// it sets the values requested at provide keys
+	// it sets the values requested at provided keys
 	// path specifies the type or location of the secrets to store
 	// secrets map specifies the "key": "value" pairs of secrets to store
 	StoreSecrets(path string, secrets map[string]string) error

--- a/pkg/client.go
+++ b/pkg/client.go
@@ -16,11 +16,17 @@
 // implementations.
 package pkg
 
-// SecretClient provides a contract for retrieving secrets from a secret store manager.
+// SecretClient provides a contract for storing and retrieving secrets from a secret store provider.
 type SecretClient interface {
 	// GetSecrets retrieves secrets from a secret store.
 	// path specifies the type or location of the secrets to retrieve.
 	// keys specifies the secrets which to retrieve. If no keys are provided then all the keys associated with the
 	// specified path will be returned.
 	GetSecrets(path string, keys ...string) (map[string]string, error)
+
+	// StoreSecrets stores the secrets to a secret store.
+	// it sets the values requested at provide keys
+	// path specifies the type or location of the secrets to store
+	// secrets map specifies the "key": "value" pairs of secrets to store
+	StoreSecrets(path string, secrets map[string]string) error
 }

--- a/pkg/providers/vault/client.go
+++ b/pkg/providers/vault/client.go
@@ -242,16 +242,15 @@ func (c Client) store(path string, secrets map[string]string) error {
 	if err != nil {
 		return err
 	}
-
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return pkg.NewErrSecretStore(fmt.Sprintf("Received a '%d' response from the secret store", resp.StatusCode))
-	}
-
 	defer func() {
 		if resp.Body != nil {
 			resp.Body.Close()
 		}
 	}()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return pkg.NewErrSecretStore(fmt.Sprintf("Received a '%d' response from the secret store", resp.StatusCode))
+	}
 
 	return nil
 }

--- a/pkg/providers/vault/client.go
+++ b/pkg/providers/vault/client.go
@@ -15,6 +15,7 @@
 package vault
 
 import (
+	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -72,16 +73,12 @@ func (c Client) GetSecrets(path string, keys ...string) (map[string]string, erro
 		// do some retries
 		// note the limit is 1 + additional retry attempts, cause we always need
 		// to do the first try
-		for tryNum := 0; tryNum < 1+addRetryAttempts; tryNum++ {
-			data, err = c.getAllKeys(path)
-			if err == nil {
-				break
-			}
+		data, err = c.getAllKeys(path)
 
-			// TODO: this will be run again if we hit the limit, when ideally we
-			// wouldn't wait cause we hit the limit and failed, but this is in
-			// the error case, so it's low priority to fix
+		for tryNum := 1; err != nil && tryNum < 1+addRetryAttempts; tryNum++ {
 			time.Sleep(c.HttpConfig.retryWaitPeriodTime)
+
+			data, err = c.getAllKeys(path)
 		}
 
 		// since we finished the above loop, then check if the last iteration
@@ -189,4 +186,72 @@ func createHTTPClient(config SecretConfig) (Caller, error) {
 			},
 		},
 	}, nil
+}
+
+func (c Client) StoreSecrets(path string, secrets map[string]string) error {
+
+	var err error
+	addRetryAttempts := c.HttpConfig.AdditionalRetryAttempts
+	switch {
+	case addRetryAttempts < 0:
+		err = pkg.NewErrSecretStore(fmt.Sprintf("invalid retry attempts setting %d", addRetryAttempts))
+	case addRetryAttempts == 0:
+		// no retries
+		err = c.store(path, secrets)
+	case addRetryAttempts > 0:
+		// do some retries
+		// note the limit is 1 + additional retry attempts, cause we always need
+		// to do the first try
+		err = c.store(path, secrets)
+
+		for tryNum := 1; err != nil && tryNum < 1+addRetryAttempts; tryNum++ {
+			time.Sleep(c.HttpConfig.retryWaitPeriodTime)
+
+			err = c.store(path, secrets)
+		}
+	}
+
+	return err
+}
+
+func (c Client) store(path string, secrets map[string]string) error {
+	if len(secrets) == 0 {
+		// nothing to store
+		return nil
+	}
+
+	url := c.HttpConfig.BuildURL() + path
+
+	payload, err := json.Marshal(secrets)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(payload))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set(c.HttpConfig.Authentication.AuthType, c.HttpConfig.Authentication.AuthToken)
+
+	if c.HttpConfig.Namespace != "" {
+		req.Header.Set(NamespaceHeader, c.HttpConfig.Namespace)
+	}
+
+	resp, err := c.HttpCaller.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return pkg.NewErrSecretStore(fmt.Sprintf("Received a '%d' response from the secret store", resp.StatusCode))
+	}
+
+	defer func() {
+		if resp.Body != nil {
+			resp.Body.Close()
+		}
+	}()
+
+	return nil
 }

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -25,7 +25,7 @@ type ErrSecretStore struct {
 }
 
 func (e ErrSecretStore) Error() string {
-	return fmt.Sprintf("Unable to obtain secrets from underlying data-store: %s", e.description)
+	return fmt.Sprintf("Error found on handling secrets from underlying data-store: %s", e.description)
 }
 
 // NewErrSecretStore creates an ErrSecretStore error type.


### PR DESCRIPTION
  - Add a new StoreSecrets API with a provided path to call
  - Update the InMemoryListener to also store secrets for unit testing

  Fixes #39 

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>