### PR TITLE
Add minimum supported Go version 1.12 to go.mod.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,5 @@ require (
 	github.com/gorilla/context v1.1.1
 	github.com/gorilla/mux v1.7.1
 )
+
+go 1.12


### PR DESCRIPTION
Fix #30 

Locally, I upgraded to Go `1.12`, and tested it out via `Makefile`.