### PR TITLE
Migrate Security Features From go-mod-bootstrap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,5 @@
 module github.com/edgexfoundry/go-mod-secrets
 
-require (
-	github.com/BurntSushi/toml v0.3.1
-	github.com/gorilla/context v1.1.1
-	github.com/gorilla/mux v1.7.1
-)
+require github.com/stretchr/testify v1.3.0
 
 go 1.12

--- a/pkg/token/authtokenloader/interface.go
+++ b/pkg/token/authtokenloader/interface.go
@@ -1,0 +1,23 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package authtokenloader
+
+// AuthTokenLoader returns authorization token for secret store
+type AuthTokenLoader interface {
+	// Load loads and returns authorization token
+	Load(path string) (string, error)
+}

--- a/pkg/token/authtokenloader/methods.go
+++ b/pkg/token/authtokenloader/methods.go
@@ -1,0 +1,66 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package authtokenloader
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/edgexfoundry/go-mod-secrets/pkg/token/fileioperformer"
+)
+
+type tokenProvider struct {
+	fileOpener fileioperformer.FileIoPerformer
+}
+
+// NewAuthTokenLoader creates a new TokenParser
+func NewAuthTokenLoader(opener fileioperformer.FileIoPerformer) AuthTokenLoader {
+	return &tokenProvider{fileOpener: opener}
+}
+
+func (p *tokenProvider) Load(path string) (authToken string, err error) {
+	reader, err := p.fileOpener.OpenFileReader(path, os.O_RDONLY, 0400)
+	if err != nil {
+		return
+	}
+	readCloser := fileioperformer.MakeReadCloser(reader)
+	fileContents, err := ioutil.ReadAll(readCloser)
+	if err != nil {
+		return
+	}
+	defer readCloser.Close()
+
+	var parsedContents vaultTokenFile
+	err = json.Unmarshal(fileContents, &parsedContents)
+	if err != nil {
+		return
+	}
+
+	// Look for token first in "auth"/"client_token"
+	// and then in "root_token"
+	// and fail if no token is found at all
+	if parsedContents.Auth.ClientToken != "" {
+		authToken = parsedContents.Auth.ClientToken
+	} else if parsedContents.RootToken != "" {
+		authToken = parsedContents.RootToken
+	} else {
+		err = fmt.Errorf("Unable to find authentication token in %s", path)
+	}
+	return
+}

--- a/pkg/token/authtokenloader/methods_test.go
+++ b/pkg/token/authtokenloader/methods_test.go
@@ -1,0 +1,79 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package authtokenloader
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	. "github.com/edgexfoundry/go-mod-secrets/pkg/token/fileioperformer/mocks"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const createTokenJSON = `{"auth":{"client_token":"some-token-value"}}`
+const vaultInitJSON = `{"root_token":"some-token-value"}`
+const expectedToken = "some-token-value"
+
+func TestReadCreateTokenJSON(t *testing.T) {
+	stringReader := strings.NewReader(createTokenJSON)
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("OpenFileReader", "/dev/null", os.O_RDONLY, os.FileMode(0400)).Return(stringReader, nil)
+
+	p := NewAuthTokenLoader(mockFileIoPerformer)
+
+	token, err := p.Load("/dev/null")
+	assert.Nil(t, err)
+	assert.Equal(t, expectedToken, token)
+}
+
+func TestReadVaultInitJSON(t *testing.T) {
+	stringReader := strings.NewReader(vaultInitJSON)
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("OpenFileReader", "/dev/null", os.O_RDONLY, os.FileMode(0400)).Return(stringReader, nil)
+
+	p := NewAuthTokenLoader(mockFileIoPerformer)
+
+	token, err := p.Load("/dev/null")
+	assert.Nil(t, err)
+	assert.Equal(t, expectedToken, token)
+}
+
+func TestReadEmptyJSON(t *testing.T) {
+	stringReader := strings.NewReader("{}")
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("OpenFileReader", "/dev/null", os.O_RDONLY, os.FileMode(0400)).Return(stringReader, nil)
+
+	p := NewAuthTokenLoader(mockFileIoPerformer)
+
+	_, err := p.Load("/dev/null")
+	assert.EqualError(t, err, "Unable to find authentication token in /dev/null")
+}
+
+func TestFailOpen(t *testing.T) {
+	stringReader := strings.NewReader("")
+	myerr := errors.New("error")
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("OpenFileReader", "/dev/null", os.O_RDONLY, os.FileMode(0400)).Return(stringReader, myerr)
+
+	p := NewAuthTokenLoader(mockFileIoPerformer)
+
+	_, err := p.Load("/dev/null")
+	assert.Equal(t, myerr, err)
+}

--- a/pkg/token/authtokenloader/mocks/mock.go
+++ b/pkg/token/authtokenloader/mocks/mock.go
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package mocks
+
+import (
+	"github.com/stretchr/testify/mock"
+)
+
+type MockAuthTokenLoader struct {
+	mock.Mock
+}
+
+func (m *MockAuthTokenLoader) Load(path string) (string, error) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(path)
+	return arguments.String(0), arguments.Error(1)
+}

--- a/pkg/token/authtokenloader/mocks/mock_test.go
+++ b/pkg/token/authtokenloader/mocks/mock_test.go
@@ -1,0 +1,42 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package mocks
+
+import (
+	"testing"
+
+	. "github.com/edgexfoundry/go-mod-secrets/pkg/token/authtokenloader"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockInterfaceType(t *testing.T) {
+	// Typecast will fail if doesn't implement interface properly
+	var iface AuthTokenLoader = &MockAuthTokenLoader{}
+	assert.NotNil(t, iface)
+}
+
+func TestMockLoad(t *testing.T) {
+	o := &MockAuthTokenLoader{}
+	o.On("Load", "path").Return("abcd", nil)
+
+	token, err := o.Load("path")
+
+	o.AssertExpectations(t)
+	assert.Nil(t, err)
+	assert.Equal(t, "abcd", token)
+}

--- a/pkg/token/authtokenloader/types.go
+++ b/pkg/token/authtokenloader/types.go
@@ -1,0 +1,28 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package authtokenloader
+
+type vaultTokenFile struct {
+	// Auth comes from the create token API
+	Auth authObject `json:"auth"`
+	// RootToken comes from the vault-init response
+	RootToken string `json:"root_token"`
+}
+
+type authObject struct {
+	ClientToken string `json:"client_token"`
+}

--- a/pkg/token/fileioperformer/interface.go
+++ b/pkg/token/fileioperformer/interface.go
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileioperformer
+
+import (
+	"io"
+	"os"
+)
+
+type FileIoPerformer interface {
+	// OpenFileReader is a function that opens a file and returns an io.Reader (at a minimum)
+	OpenFileReader(name string, flag int, perm os.FileMode) (io.Reader, error)
+	// OpenFileWriter is a function that opens a file and returns an io.WriteCloser (at a minimum)
+	OpenFileWriter(name string, flag int, perm os.FileMode) (io.WriteCloser, error)
+	// MkdirAll creates a directory tree (see os.MkdirAll)
+	MkdirAll(path string, perm os.FileMode) error
+}

--- a/pkg/token/fileioperformer/methods.go
+++ b/pkg/token/fileioperformer/methods.go
@@ -1,0 +1,51 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileioperformer
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+type defaultFileIoPerformer struct{}
+
+func NewDefaultFileIoPerformer() FileIoPerformer {
+	return &defaultFileIoPerformer{}
+}
+
+func (*defaultFileIoPerformer) OpenFileReader(name string, flag int, perm os.FileMode) (io.Reader, error) {
+	return os.OpenFile(name, flag, perm)
+}
+
+func (*defaultFileIoPerformer) OpenFileWriter(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+	return os.OpenFile(name, flag, perm)
+}
+
+func (*defaultFileIoPerformer) MkdirAll(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+// MakeReadCloser will turn an an io.Reader into an io.ReadCloser
+// if the underlying object does not already support io.ReadCloser
+func MakeReadCloser(reader io.Reader) io.ReadCloser {
+	rc, ok := reader.(io.ReadCloser)
+	if !ok && reader != nil {
+		rc = ioutil.NopCloser(reader)
+	}
+	return rc
+}

--- a/pkg/token/fileioperformer/methods_test.go
+++ b/pkg/token/fileioperformer/methods_test.go
@@ -1,0 +1,117 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileioperformer
+
+import (
+	"io"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//
+// Note: these tests do real I/O.
+// Filenames are chosen so as to make this I/O harmless
+//
+
+func TestFileIoPerformerReader(t *testing.T) {
+
+	fileio := NewDefaultFileIoPerformer()
+
+	if isLinux() {
+		reader, err := fileio.OpenFileReader("/dev/null", os.O_RDONLY, 0400)
+		assert.Nil(t, err)
+		assert.NotNil(t, fileio)
+		assert.NotNil(t, reader)
+	}
+}
+
+func TestFileIoPerformerWriter(t *testing.T) {
+
+	fileio := NewDefaultFileIoPerformer()
+
+	if isLinux() {
+		writer, err := fileio.OpenFileWriter("/dev/null", os.O_RDONLY, 0400)
+		assert.Nil(t, err)
+		assert.NotNil(t, fileio)
+		assert.NotNil(t, writer)
+	}
+}
+
+func TestFileIoPerformerMkdirAll(t *testing.T) {
+
+	fileio := NewDefaultFileIoPerformer()
+
+	if isLinux() {
+		err := fileio.MkdirAll("/tmp", 0777)
+		assert.Nil(t, err)
+	}
+}
+
+func TestMakeReadCloserPassThru(t *testing.T) {
+
+	var mockReadCloser io.ReadCloser = &mockReadCloser{}
+	var mockReader = mockReadCloser.(io.Reader)
+
+	result := MakeReadCloser(mockReader)
+	result2 := MakeReadCloser(mockReadCloser)
+
+	// In all cases, should just get the original object back
+
+	assert.Implements(t, (*io.ReadCloser)(nil), result)
+	assert.Implements(t, (*io.ReadCloser)(nil), result2)
+
+	assert.Equal(t, mockReadCloser, result)
+	assert.Equal(t, mockReadCloser, result2)
+}
+
+func TestMakeReadCloserNopCloser(t *testing.T) {
+
+	var mockReader = &mockReader{}
+
+	result := MakeReadCloser(mockReader)
+
+	// Should get back an object with a NopCloser wrapper
+
+	assert.Implements(t, (*io.ReadCloser)(nil), result)
+}
+
+func isLinux() bool {
+	return runtime.GOOS == "linux"
+}
+
+//
+// mocking support
+//
+
+type mockReadCloser struct{}
+
+func (rc *mockReadCloser) Read(p []byte) (n int, err error) {
+	return 0, nil
+}
+
+func (rc *mockReadCloser) Close() error {
+	return nil
+}
+
+type mockReader struct{}
+
+func (rc *mockReader) Read(p []byte) (n int, err error) {
+	return 0, nil
+}

--- a/pkg/token/fileioperformer/mocks/mock.go
+++ b/pkg/token/fileioperformer/mocks/mock.go
@@ -1,0 +1,46 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package mocks
+
+import (
+	"io"
+	"os"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MockFileIoPerformer struct {
+	mock.Mock
+}
+
+func (m *MockFileIoPerformer) OpenFileReader(name string, flag int, perm os.FileMode) (io.Reader, error) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(name, flag, perm)
+	return arguments.Get(0).(io.Reader), arguments.Error(1)
+}
+
+func (m *MockFileIoPerformer) OpenFileWriter(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(name, flag, perm)
+	return arguments.Get(0).(io.WriteCloser), arguments.Error(1)
+}
+
+func (m *MockFileIoPerformer) MkdirAll(path string, perm os.FileMode) error {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(path, perm)
+	return arguments.Error(0)
+}

--- a/pkg/token/fileioperformer/mocks/mock_test.go
+++ b/pkg/token/fileioperformer/mocks/mock_test.go
@@ -1,0 +1,79 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package mocks
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/edgexfoundry/go-mod-secrets/pkg/token/fileioperformer"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockInterfaceType(t *testing.T) {
+	// Typecast will fail if doesn't implement interface properly
+	var iface FileIoPerformer = &MockFileIoPerformer{}
+	assert.NotNil(t, iface)
+}
+
+func TestMockOpenFileReader(t *testing.T) {
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("OpenFileReader", "/dev/null", os.O_RDONLY, os.FileMode(0400)).Return(&fakeReaderWriter{}, nil)
+
+	obj, err := mockFileIoPerformer.OpenFileReader("/dev/null", os.O_RDONLY, os.FileMode(0400))
+	assert.NotNil(t, obj)
+	assert.Nil(t, err)
+	mockFileIoPerformer.AssertExpectations(t)
+}
+
+func TestMockOpenFileWriter(t *testing.T) {
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("OpenFileWriter", "/dev/null", os.O_WRONLY, os.FileMode(0500)).Return(&fakeReaderWriter{}, nil)
+
+	obj, err := mockFileIoPerformer.OpenFileWriter("/dev/null", os.O_WRONLY, os.FileMode(0500))
+	assert.NotNil(t, obj)
+	assert.Nil(t, err)
+	mockFileIoPerformer.AssertExpectations(t)
+}
+
+func TestMockMkdirAll(t *testing.T) {
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("MkdirAll", "/tmp/foo", os.FileMode(0700)).Return(nil)
+
+	err := mockFileIoPerformer.MkdirAll("/tmp/foo", os.FileMode(0700))
+	assert.Nil(t, err)
+	mockFileIoPerformer.AssertExpectations(t)
+}
+
+//
+// fakes
+//
+
+type fakeReaderWriter struct{}
+
+func (*fakeReaderWriter) Close() error {
+	return nil
+}
+
+func (m *fakeReaderWriter) Read(b []byte) (n int, err error) {
+	return 0, nil
+}
+
+func (m *fakeReaderWriter) Write(p []byte) (n int, err error) {
+	return 0, nil
+}


### PR DESCRIPTION
Fix #43

Move the security features related to getting a token for the secret
client since this project handles security related functionality.

Rename the directory from 'security' to 'token' to better represent its
place in this project.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>