### PR TITLE
Implement token refresh background process [issue #34]

### DIFF
--- a/pkg/providers/vault/client_test.go
+++ b/pkg/providers/vault/client_test.go
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright 2019 Dell Inc.
+ * Copyright 2020 Intel Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,12 +17,18 @@ package vault
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -111,12 +118,30 @@ func (immc *InMemoryMockCaller) Do(req *http.Request) (*http.Response, error) {
 }
 
 func TestNewSecretClient(t *testing.T) {
-	cfgHTTP := SecretConfig{Host: "localhost", Port: 8080}
-	cfgInvalidCertPath := SecretConfig{Host: "localhost", Port: 8080, RootCaCertPath: "/non-existent-directory/rootCa.crt"}
-	cfgNamespace := SecretConfig{Host: "localhost", Port: 8080, Namespace: "database"}
-	cfgInvalidTime := SecretConfig{Host: "localhost", Port: 8080, RetryWaitPeriod: "not a real time spec"}
-	cfgValidTime := SecretConfig{Host: "localhost", Port: 8080, RetryWaitPeriod: "1s"}
+	authToken := "testToken"
+	var tokenDataMap sync.Map
+	tokenDataMap.Store(authToken, TokenLookupMetadata{
+		Renewable: true,
+		Ttl:       10000,
+		Period:    10000,
+	})
+	server := getMockTokenServer(&tokenDataMap)
+	defer server.Close()
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Errorf("error on parsing server url %s: %s", server.URL, err)
+	}
+	host, port, _ := net.SplitHostPort(serverURL.Host)
+	portNum, _ := strconv.Atoi(port)
+
+	cfgHTTP := SecretConfig{Protocol: "http", Host: host, Port: portNum, Authentication: AuthenticationInfo{AuthToken: authToken}}
+	cfgInvalidCertPath := SecretConfig{Protocol: "https", Host: host, Port: portNum, RootCaCertPath: "/non-existent-directory/rootCa.crt", Authentication: AuthenticationInfo{AuthToken: authToken}}
+	cfgNamespace := SecretConfig{Protocol: "http", Host: host, Port: portNum, Namespace: "database", Authentication: AuthenticationInfo{AuthToken: authToken}}
+	cfgInvalidTime := SecretConfig{Protocol: "http", Host: host, Port: portNum, RetryWaitPeriod: "not a real time spec", Authentication: AuthenticationInfo{AuthToken: authToken}}
+	cfgValidTime := SecretConfig{Protocol: "http", Host: host, Port: portNum, RetryWaitPeriod: "1s", Authentication: AuthenticationInfo{AuthToken: authToken}}
+	cfgEmptyToken := SecretConfig{Protocol: "http", Host: host, Port: portNum, RetryWaitPeriod: "1s"}
 	s := time.Second
+	bkgCtx := context.Background()
 
 	tests := []struct {
 		name         string
@@ -129,10 +154,18 @@ func TestNewSecretClient(t *testing.T) {
 		{"NewSecretClient with Namespace", cfgNamespace, false, nil},
 		{"NewSecretClient with invalid RetryWaitPeriod", cfgInvalidTime, true, nil},
 		{"NewSecretClient with valid RetryWaitPeriod", cfgValidTime, false, &s},
+		{"NewSecretClient with empty token", cfgEmptyToken, true, nil},
 	}
+	mockLogger := NewMockClient()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := NewSecretClient(tt.cfg)
+
+			factory := NewSecretClientFactory()
+
+			emptyTokenCallbackFunc := func(expiredToken string) (replacementToken string, retry bool) {
+				return "", false
+			}
+			c, err := factory.NewSecretClient(bkgCtx, tt.cfg, mockLogger, emptyTokenCallbackFunc)
 			if err != nil {
 				if !tt.expectErr {
 					t.Errorf("unexpected error: %v", err)
@@ -372,7 +405,7 @@ func TestHttpSecretStoreManager_GetValue(t *testing.T) {
 
 			actual, err := ssm.GetSecrets(test.path, test.keys...)
 			if test.expectedErrorType != nil && err == nil {
-				t.Errorf("Expected error %v but none was recieved", test.expectedErrorType)
+				t.Errorf("Expected error %v but none was received", test.expectedErrorType)
 			}
 
 			switch v := test.caller.(type) {
@@ -567,7 +600,7 @@ func TestHttpSecretStoreManager_SetValue(t *testing.T) {
 
 			err := ssm.StoreSecrets(test.path, test.secrets)
 			if test.expectedErrorType != nil && err == nil {
-				t.Errorf("Expected error %v but none was recieved", test.expectedErrorType)
+				t.Errorf("Expected error %v but none was received", test.expectedErrorType)
 			}
 
 			switch v := test.caller.(type) {
@@ -595,7 +628,7 @@ func TestHttpSecretStoreManager_SetValue(t *testing.T) {
 
 			if !test.expectError && test.secrets != nil {
 				keys := make([]string, 0, len(test.secrets))
-				for k, _ := range test.secrets {
+				for k := range test.secrets {
 					keys = append(keys, k)
 				}
 				actual, _ := ssm.GetSecrets(test.path, keys...)
@@ -608,4 +641,343 @@ func TestHttpSecretStoreManager_SetValue(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMultipleTokenRenewals(t *testing.T) {
+	// run in parallel with other tests
+	t.Parallel()
+	// setup
+	tokenPeriod := 6
+	var tokenDataMap sync.Map
+	// ttl > half of period
+	tokenDataMap.Store("testToken1", TokenLookupMetadata{
+		Renewable: true,
+		Ttl:       tokenPeriod * 7 / 10,
+		Period:    tokenPeriod,
+	})
+	// ttl = half of period
+	tokenDataMap.Store("testToken2", TokenLookupMetadata{
+		Renewable: true,
+		Ttl:       tokenPeriod / 2,
+		Period:    tokenPeriod,
+	})
+	// ttl < half of period
+	tokenDataMap.Store("testToken3", TokenLookupMetadata{
+		Renewable: true,
+		Ttl:       tokenPeriod * 3 / 10,
+		Period:    tokenPeriod,
+	})
+	// to be expired token
+	tokenDataMap.Store("toToExpiredToken", TokenLookupMetadata{
+		Renewable: true,
+		Ttl:       1,
+		Period:    tokenPeriod,
+	})
+	// expired token
+	tokenDataMap.Store("expiredToken", TokenLookupMetadata{
+		Renewable: true,
+		Ttl:       0,
+		Period:    tokenPeriod,
+	})
+	// not renewable token
+	tokenDataMap.Store("unrenewableToken", TokenLookupMetadata{
+		Renewable: false,
+		Ttl:       0,
+		Period:    tokenPeriod,
+	})
+
+	server := getMockTokenServer(&tokenDataMap)
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Errorf("error on parsing server url %s: %s", server.URL, err)
+	}
+	host, port, _ := net.SplitHostPort(serverURL.Host)
+	portNum, _ := strconv.Atoi(port)
+
+	bkgCtx := context.Background()
+
+	mockLogger := NewMockClient()
+	tests := []struct {
+		name                     string
+		authToken                string
+		retries                  int
+		tokenExpiredCallbackFunc tokenExpiredCallback
+		expectError              bool
+		expectedErrorType        error
+	}{
+		{
+			name:              "New secret client with testToken1, more than half of TTL remaining",
+			authToken:         "testToken1",
+			expectError:       false,
+			expectedErrorType: nil,
+		},
+		{
+			name:              "New secret client with the same first token again",
+			authToken:         "testToken1",
+			expectError:       false,
+			expectedErrorType: nil,
+		},
+		{
+			name:              "New secret client with testToken2, half of TTL remaining",
+			authToken:         "testToken2",
+			expectError:       false,
+			expectedErrorType: nil,
+		},
+		{
+			name:              "New secret client with testToken3, less than half of TTL remaining",
+			authToken:         "testToken3",
+			expectError:       false,
+			expectedErrorType: nil,
+		},
+		{
+			name:              "New secret client with expired token, no TTL remaining",
+			authToken:         "expiredToken",
+			expectError:       true,
+			expectedErrorType: errHTTPResponse{statusCode: 403, errMsg: "forbidden"},
+		},
+		{
+			name:              "New secret client with expired token, no TTL remaining, 3 retries",
+			authToken:         "expiredToken",
+			retries:           3,
+			expectError:       true,
+			expectedErrorType: errHTTPResponse{statusCode: 403, errMsg: "forbidden"},
+		},
+		{
+			name:              "New secret client with unauthenticated token",
+			authToken:         "invalidToken",
+			expectError:       true,
+			expectedErrorType: errHTTPResponse{statusCode: 403, errMsg: "forbidden"},
+		},
+		{
+			name:              "New secret client with unrenewable token",
+			authToken:         "unrenewableToken",
+			expectError:       false,
+			expectedErrorType: nil,
+		},
+		{
+			name:      "New secret client with to be expired token, 3 retries, retry func",
+			authToken: "toToExpiredToken",
+			retries:   3,
+			tokenExpiredCallbackFunc: func(expiredToken string) (replacementToken string, retry bool) {
+				time.Sleep(1 * time.Second)
+				return "testToken1", true
+			},
+			expectError:       false,
+			expectedErrorType: nil,
+		},
+	}
+
+	factory := NewSecretClientFactory()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfgHTTP := SecretConfig{
+				Host:                    host,
+				Port:                    portNum,
+				Protocol:                "http",
+				Authentication:          AuthenticationInfo{AuthToken: test.authToken},
+				AdditionalRetryAttempts: test.retries,
+			}
+
+			c, err := factory.NewSecretClient(bkgCtx, cfgHTTP, mockLogger, test.tokenExpiredCallbackFunc)
+
+			if test.expectedErrorType != nil && err == nil {
+				t.Errorf("Expected error %v but none was received", test.expectedErrorType)
+			}
+
+			if !test.expectError && err != nil {
+				t.Errorf("Unexpected error: %s", err.Error())
+			}
+
+			if test.expectError && test.expectedErrorType != nil && err != nil {
+				eet := reflect.TypeOf(test.expectedErrorType)
+				aet := reflect.TypeOf(err)
+				if !aet.AssignableTo(eet) {
+					t.Errorf("Expected error of type %v, but got an error of type %v", eet, aet)
+				}
+			}
+
+			client := c.(Client)
+
+			// look up the token data again after renewal
+			lookupTokenData, err := client.getTokenLookupResponseData()
+			if !test.expectError && err != nil {
+				t.Errorf("error on cfgAuthToken %s: %s", test.authToken, err)
+			}
+
+			if !test.expectError && lookupTokenData.Data.Renewable &&
+				lookupTokenData.Data.Ttl < tokenPeriod/2 {
+				tokenData, _ := tokenDataMap.Load(test.authToken)
+				tokenTTL := tokenData.(TokenLookupMetadata).Ttl
+				t.Errorf("failed to renew token with the token period %d: the current TTL %d and the old TTL: %d",
+					tokenPeriod, lookupTokenData.Data.Ttl, tokenTTL)
+			}
+		})
+	}
+	// wait for some time to allow renewToken to be run if any
+	time.Sleep(7 * time.Second)
+}
+
+func TestMultipleClientsFailureCase(t *testing.T) {
+	// run in parallel with other tests
+	t.Parallel()
+	// setup
+	tokenPeriod := 6
+	var tokenDataMap sync.Map
+
+	// expired token
+	tokenDataMap.Store("expiredToken", TokenLookupMetadata{
+		Renewable: true,
+		Ttl:       0,
+		Period:    tokenPeriod,
+	})
+
+	server := getMockTokenServer(&tokenDataMap)
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Errorf("error on parsing server url %s: %s", server.URL, err)
+	}
+	host, port, _ := net.SplitHostPort(serverURL.Host)
+	portNum, _ := strconv.Atoi(port)
+
+	bkgCtx := context.Background()
+
+	mockLogger := NewMockClient()
+	factory := NewSecretClientFactory()
+	cfgHTTP := SecretConfig{
+		Host:           host,
+		Port:           portNum,
+		Protocol:       "http",
+		Authentication: AuthenticationInfo{AuthToken: "expiredToken"},
+	}
+
+	emptyTokenCallbackFunc := func(expiredToken string) (replacementToken string, retry bool) {
+		return "", false
+	}
+	_, err = factory.NewSecretClient(bkgCtx, cfgHTTP, mockLogger, emptyTokenCallbackFunc)
+	// it will fail since the token is expired
+	if err == nil {
+		t.Errorf("expecting an error for expired token")
+	}
+
+	// create a second secret client with the same expired token
+	_, err = factory.NewSecretClient(bkgCtx, cfgHTTP, mockLogger, emptyTokenCallbackFunc)
+	if err == nil {
+		t.Errorf("expecting an error for expired token")
+	} else {
+		fmt.Println(err)
+	}
+	// wait for some time to allow renewToken to be run if any
+	time.Sleep(10 * time.Second)
+}
+
+func TestConcurrentSecretClientTokenRenewals(t *testing.T) {
+	// run in parallel with other tests
+	t.Parallel()
+	// setup
+	tokenPeriod := 6
+	var tokenDataMap sync.Map
+
+	// ttl < half of period
+	tokenDataMap.Store("testToken3", TokenLookupMetadata{
+		Renewable: true,
+		Ttl:       tokenPeriod * 3 / 10,
+		Period:    tokenPeriod,
+	})
+
+	server := getMockTokenServer(&tokenDataMap)
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Errorf("error on parsing server url %s: %s", server.URL, err)
+	}
+	host, port, _ := net.SplitHostPort(serverURL.Host)
+	portNum, _ := strconv.Atoi(port)
+
+	bkgCtx := context.Background()
+	mockLogger := NewMockClient()
+	factory := NewSecretClientFactory()
+	cfgHTTP := SecretConfig{
+		Host:           host,
+		Port:           portNum,
+		Protocol:       "http",
+		Authentication: AuthenticationInfo{AuthToken: "testToken3"},
+	}
+
+	// number of clients to be created to run in go-routines
+	numOfClients := 100
+	for i := 0; i < numOfClients; i++ {
+		go func(ith int) {
+			emptyTokenCallbackFunc := func(expiredToken string) (replacementToken string, retry bool) {
+				return "", false
+			}
+			_, err = factory.NewSecretClient(bkgCtx, cfgHTTP, mockLogger, emptyTokenCallbackFunc)
+			// verify if any error
+			if err != nil {
+				t.Errorf("found error in secret client %d: %v", ith, err)
+			}
+			time.Sleep(15 * time.Second)
+		}(i)
+	}
+
+	// wait for some time to allow renewToken to be run if any
+	time.Sleep(15 * time.Second)
+}
+
+func getMockTokenServer(tokenDataMap *sync.Map) *httptest.Server {
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		urlPath := req.URL.String()
+		if req.Method == http.MethodGet && urlPath == "/v1/auth/token/lookup-self" {
+			token := req.Header.Get(AuthTypeHeader)
+			sampleTokenLookup, exists := tokenDataMap.Load(token)
+			if !exists {
+				rw.WriteHeader(403)
+				_, _ = rw.Write([]byte("permission denied"))
+			} else {
+				resp := &TokenLookupResponse{
+					Data: sampleTokenLookup.(TokenLookupMetadata),
+				}
+				if ret, err := json.Marshal(resp); err != nil {
+					rw.WriteHeader(500)
+					_, _ = rw.Write([]byte(err.Error()))
+				} else {
+					rw.WriteHeader(200)
+					_, _ = rw.Write(ret)
+				}
+			}
+		} else if req.Method == http.MethodPost && urlPath == "/v1/auth/token/renew-self" {
+			token := req.Header.Get(AuthTypeHeader)
+			sampleTokenLookup, exists := tokenDataMap.Load(token)
+			if !exists {
+				rw.WriteHeader(403)
+				_, _ = rw.Write([]byte("permission denied"))
+			} else {
+				currentTTL := sampleTokenLookup.(TokenLookupMetadata).Ttl
+				if currentTTL <= 0 {
+					// already expired
+					rw.WriteHeader(403)
+					_, _ = rw.Write([]byte("permission denied"))
+				} else {
+					tokenPeriod := sampleTokenLookup.(TokenLookupMetadata).Period
+
+					tokenDataMap.Store(token, TokenLookupMetadata{
+						Renewable: true,
+						Ttl:       tokenPeriod,
+						Period:    tokenPeriod,
+					})
+					rw.WriteHeader(200)
+					_, _ = rw.Write([]byte("token renewed"))
+				}
+			}
+		} else {
+			rw.WriteHeader(404)
+			_, _ = rw.Write([]byte(fmt.Sprintf("Unknown urlPath: %s", urlPath)))
+		}
+	}))
+	return server
 }

--- a/pkg/providers/vault/errors.go
+++ b/pkg/providers/vault/errors.go
@@ -1,6 +1,23 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ * Copyright 2020 Intel Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
 package vault
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // ErrCaRootCert error when the provided CA Root certificate is invalid.
 type ErrCaRootCert struct {
@@ -10,4 +27,13 @@ type ErrCaRootCert struct {
 
 func (e ErrCaRootCert) Error() string {
 	return fmt.Sprintf("Unable to use the certificate '%s': %s", e.path, e.description)
+}
+
+type errHTTPResponse struct {
+	statusCode int
+	errMsg     string
+}
+
+func (err errHTTPResponse) Error() string {
+	return fmt.Sprintf("HTTP response with status code %d, message: %s", err.statusCode, err.errMsg)
 }

--- a/pkg/providers/vault/factory.go
+++ b/pkg/providers/vault/factory.go
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ * Copyright 2020 Intel Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package vault
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/edgexfoundry/go-mod-secrets/pkg"
+)
+
+// a map variable to handle the case of the same caller to have
+// multiple secret clients with potentially the same tokens while renewing token
+// in the background go-routine
+type vaultTokenToCancelFuncMap map[string]context.CancelFunc
+
+type secretClientFactory struct {
+	// tokenCancelFunc is an internal map with token as key and
+	// the context.cancel function as value
+	tokenCancelFunc vaultTokenToCancelFuncMap
+	// mapMutex protects the internal map cache from race conditions
+	mapMutex *sync.Mutex
+}
+
+// NewSecretClientFactory creates a new factory for manufacturing secret clients
+// the facotry is maintaining an internal map of Vault tokens and context cancel functions
+// for gracefully terminating the background goroutine per token
+func NewSecretClientFactory() *secretClientFactory {
+	return &secretClientFactory{
+		tokenCancelFunc: make(vaultTokenToCancelFuncMap),
+		mapMutex:        &sync.Mutex{},
+	}
+}
+
+// NewSecretClient constructs a SecretClient which communicates with Vault via HTTP(S)
+//
+// lc is any logging client that implements the loggingClient interface;
+// today EdgeX's logger.LoggingClient from go-mod-core-contracts satisfies this implementation
+//
+// ctx is the background context that can be used to cancel or cleanup
+// the background process when it is no longer needed
+//
+// tokenExpiredCallback is the callback function dealing with the expired token
+// and getting a replacement token
+// it can be nil if the caller choose not to do that
+func (factory *secretClientFactory) NewSecretClient(ctx context.Context,
+	config SecretConfig,
+	lc loggingClient,
+	tokenExpiredCallback tokenExpiredCallback) (pkg.SecretClient, error) {
+	if ctx == nil {
+		return nil, pkg.NewErrSecretStore("background ctx is required and cannot be nil")
+	}
+
+	tokenStr := config.Authentication.AuthToken
+	if tokenStr == "" {
+		return nil, pkg.NewErrSecretStore("AuthToken is required in config")
+	}
+
+	httpClient, err := createHTTPClient(config)
+	if err != nil {
+		return Client{}, err
+	}
+
+	if config.RetryWaitPeriod != "" {
+		retryTimeDuration, err := time.ParseDuration(config.RetryWaitPeriod)
+		if err != nil {
+			return nil, err
+		}
+		config.retryWaitPeriodTime = retryTimeDuration
+	}
+
+	secretClient := Client{
+		HttpConfig: config,
+		HttpCaller: httpClient,
+		lc:         lc,
+	}
+
+	factory.mapMutex.Lock()
+	// if there is context already associated with the given token,
+	// then we cancel it first
+	if cancel, exists := factory.tokenCancelFunc[tokenStr]; exists {
+		cancel()
+	}
+	factory.mapMutex.Unlock()
+
+	cCtx, cancel := context.WithCancel(ctx)
+	if err = secretClient.refreshToken(cCtx, tokenExpiredCallback); err != nil {
+		cancel()
+		factory.mapMutex.Lock()
+		delete(factory.tokenCancelFunc, tokenStr)
+		factory.mapMutex.Unlock()
+	} else {
+		factory.mapMutex.Lock()
+		factory.tokenCancelFunc[tokenStr] = cancel
+		factory.mapMutex.Unlock()
+	}
+
+	return secretClient, err
+}

--- a/pkg/providers/vault/interfaces.go
+++ b/pkg/providers/vault/interfaces.go
@@ -20,3 +20,21 @@ import "net/http"
 type Caller interface {
 	Do(req *http.Request) (*http.Response, error)
 }
+
+// tokenExpiredCallback is the callback function to handle the case when the vault token has already expired
+type tokenExpiredCallback func(expiredToken string) (replacementToken string, retry bool)
+
+// loggingClient is the interface to do the logging
+type loggingClient interface {
+	// the logger.LoggingClient from EdgeX's go-mod-core-contracts
+	// actually statisfies this interface signature
+	// and Error, Trace, and SetLogLevel are not in this interface
+	// as they are not used or referred anywhere in the local usage
+
+	// Debug logs a message at the DEBUG severity level
+	Debug(msg string, args ...interface{})
+	// Info logs a message at the INFO severity level
+	Info(msg string, args ...interface{})
+	// Warn logs a message at the WARN severity level
+	Warn(msg string, args ...interface{})
+}

--- a/pkg/providers/vault/mocklogger.go
+++ b/pkg/providers/vault/mocklogger.go
@@ -1,0 +1,37 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package vault
+
+type MockLogger struct {
+}
+
+// NewMockClient creates a mock instance of loggingClient implementation
+func NewMockClient() loggingClient {
+	return MockLogger{}
+}
+
+// Info simulates logging an entry at the INFO severity level
+func (lc MockLogger) Info(msg string, args ...interface{}) {
+}
+
+// Debug simulates logging an entry at the DEBUG severity level
+func (lc MockLogger) Debug(msg string, args ...interface{}) {
+}
+
+// Warn simulates logging an entry at the WARN severity level
+func (lc MockLogger) Warn(msg string, args ...interface{}) {
+}

--- a/pkg/providers/vault/models.go
+++ b/pkg/providers/vault/models.go
@@ -1,5 +1,4 @@
 /*******************************************************************************
- * Copyright 2019 Dell Inc.
  * Copyright 2020 Intel Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -15,8 +14,13 @@
 
 package vault
 
-const (
-	// NamespaceHeader specifies the header name to use when including Namespace information in a request.
-	NamespaceHeader = "X-Vault-Namespace"
-	AuthTypeHeader  = "X-Vault-Token"
-)
+type TokenLookupMetadata struct {
+	ExpireTime string `json:"expire_time"`
+	Period     int    `json:"period"` // in seconds
+	Renewable  bool   `json:"renewable"`
+	Ttl        int    `json:"ttl"` // in seconds
+}
+
+type TokenLookupResponse struct {
+	Data TokenLookupMetadata
+}


### PR DESCRIPTION
  Fixes issue #34 of go-mod-secrets.

  The background process is periodically checking the Vault service token's TTL every half of token's TTL.

  If the same token is given again, the go context will cancel the previous context and re-create a new one to keep it alive and preventing from creating multiple or too many background contexts for the same token.

  The Vault's token is only renewable if it is periodic token (ie. the token period is > 0) and renewable is true.

  If the TTL of token is already <= half of token's period when the call is invoked, it will renew right away before the periodic timer kicks off.

  The `NewSecretClient` constructor is now taking a reference to a loggingClient interface implementation in order to log any progress, status, and potential error occurring in the background process.  It can also take a `TokenExpiredCallback` function if the caller decides to provide a new token in the case of toke being expired during the background process.

```go
type TokenExpiredCallback func(expiredToken string) (replacementToken string, retry bool) 
```

## Testing Instruction

### Run Testing Instance of Vault server
Save the following contents of docker-compose file into your local folder and then run `docker-compose up -d` to start a local unsealed vault container running in dev mod.  
```yaml
version: '3.4'

services:
  vault:
    image: vault
    ports:
      - "8200:8200"
    environment:
      VAULT_ADDR: http://127.0.0.1:8200

```

### Obtain the Root Token
Check vaults docker logs with `docker logs <vault image id>` near the top you will see a section that has the unseal key and root token.  Copy the root token to use in the next step.

### Run the Test App
Save the following contents of main.go into your local folder:
```go
package main

import (
	"bytes"
	"context"
	"encoding/json"
	"flag"
	"fmt"
	"io/ioutil"
	"net/http"
	"os"
	"time"

	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
	"github.com/edgexfoundry/go-mod-secrets/pkg/providers/vault"
)

var rootTokenPtr = flag.String("token", "s.KhQILbtzYTGKbFQtonjuqNEQ", "token string (should be root token)")
var timeWindowPrt = flag.Int("window", 15, "how long to run the test in seconds")
var tokenPeriodPtr = flag.Int("period", 10, "token period in seconds")
var vaultHostPtr = flag.String("host", "localhost", "host of vault server")

func init() {
	// example with short version for long flag
	flag.StringVar(rootTokenPtr, "t", "s.KhQILbtzYTGKbFQtonjuqNEQ", "token string (should be root token)")
	flag.IntVar(timeWindowPrt, "w", 15, "how long to run the test in seconds")
	flag.IntVar(tokenPeriodPtr, "p", 10, "token period in seconds")
	flag.StringVar(vaultHostPtr, "h", "localhost", "host of vault server")
}

func main() {
	//Read root token
	flag.Parse()
	rootToken := *rootTokenPtr
	totalTimeWindow := time.Duration(*timeWindowPrt) * time.Second
	tokenPeriod := time.Duration(*tokenPeriodPtr) * time.Second
	vaultHost := *vaultHostPtr

	logger := logger.NewClientStdOut("test", false, "DEBUG")

	// Create token
	vaultPort := 8200
	tokenCreatePath := "/v1/auth/token/create"
	tokenLookupSelfPath := "/v1/auth/token/lookup-self"

	urlCreateToken := fmt.Sprintf("http://%s:%d%s", vaultHost, vaultPort, tokenCreatePath)
	urlLookupSelf := fmt.Sprintf("http://%s:%d%s", vaultHost, vaultPort, tokenLookupSelfPath)

	createTokenData := fmt.Sprintf(`{"ttl": "%s", "renewable": true, "period":"%s", "no_parent" : true}`, tokenPeriod.String(), tokenPeriod.String())

	response := makeHTTPCall(urlCreateToken, "POST", createTokenData, rootToken)
	var createTokenResp createTokenResponse

	if err := json.Unmarshal(response, &createTokenResp); err != nil {
		fmt.Fprintf(os.Stderr, "error: %v\n", err)
		os.Exit(1)
	}

	authToken := createTokenResp.Auth.ClientToken

	logger.Debug(fmt.Sprintf("Created new client token: %v", authToken))

	config := vault.SecretConfig{
		Protocol:       "http",
		Host:           vaultHost,
		Port:           vaultPort,
		Authentication: vault.AuthenticationInfo{AuthToken: authToken}}

	ctx := context.Background()
	tokenExpiredCallback := func(expiredToken string) (replacementToken string, retry bool) {
             return rootToken, true
        }

	// Create SecrectClient to start the token refresh cycle
	_, err := vault.NewSecretClientFactory().NewSecretClient(ctx, config, logger, tokenExpiredCallback)
	if err != nil {
		fmt.Fprintf(os.Stderr, "error: %v\n", err)
		os.Exit(1)
	}

	timesUpticker := time.NewTicker(totalTimeWindow)
	lookUpSelfTicker := time.NewTicker(1 * time.Second)
	failures := 0
	tokenRefreshes := 0
	oldTTL := 0

	// Check for errors on error channel and query lookup for ttl changes
	for {
		select {
		case <-lookUpSelfTicker.C:
			var response lookUpSelfResponse
			lookupData := makeHTTPCall(urlLookupSelf, "GET", "", authToken)

			if err := json.Unmarshal(lookupData, &response); err != nil {
				fmt.Fprintf(os.Stderr, "error: %v\n", err)
				os.Exit(1)
			}

			logger.Debug(fmt.Sprintf("Check lookup-self for token ttl: %v, period: %v", response.Data.TTL, response.Data.Period))

			// give a one second window to allow for token refresh time
			if response.Data.TTL < ((response.Data.Period / 2) - 1) {
				failures++
				logger.Debug(fmt.Sprintf("TTL fell below half of period ttl is %d, period is %d", response.Data.TTL, response.Data.Period))
			}

			if response.Data.TTL > oldTTL && oldTTL != 0 {
				tokenRefreshes++
			}

			oldTTL = response.Data.TTL

		case <-timesUpticker.C:
			logger.Debug("Time is up!")
			timesUpticker.Stop()
			lookUpSelfTicker.Stop()
			if failures > 0 {
				logger.Debug(fmt.Sprintf("Report: Token failed to refresh at least once, check the logs above for more details."))
			} else {
				logger.Debug(fmt.Sprintf("Report: Token refreshed as expected with a total time window of %s, and period of %s there were %v token refreshes.", totalTimeWindow.String(), tokenPeriod.String(), tokenRefreshes))
			}
			return
		}
	}
}

func makeHTTPCall(url string, httpMethod string, data string, token string) []byte {

	req, err := http.NewRequest(httpMethod, url, bytes.NewBuffer([]byte(data)))
	req.Header.Set("X-Vault-Token", token)
	req.Header.Set("Content-Type", "application/json")

	client := &http.Client{}
	resp, err := client.Do(req)
	if err != nil {
		fmt.Fprintf(os.Stderr, "error: %v\n", err)
		os.Exit(1)
	}
	defer resp.Body.Close()

	body, err := ioutil.ReadAll(resp.Body)

	if err != nil {
		fmt.Fprintf(os.Stderr, "error: %v\n", err)
		os.Exit(1)
	}

	return body
}

type auth struct {
	ClientToken   string `json:"client_token"`
	LeaseDuration int    `json:"lease_duration"`
	Renewable     bool   `json:"renewable"`
}

type createTokenResponse struct {
	Auth auth `json:"auth"`
}

type lookUpSelfResponse struct {
	Data lookUpSelfData `json:"data"`
}

type lookUpSelfData struct {
	TTL    int `json:"ttl"`
	Period int `json:"period"`
}

func (obj createTokenResponse) String() string {
	val, _ := json.Marshal(obj)
	return string(val)
}
```
 and then run the test golang file `go run main.go -token=<root-token-copied-from-step-2> -window=12 -period=6 -host=localhost`

The tests should output log messages indicating the progress.  

Below is an example of what the output should look like for a passing test (I removed some extra logging info for brevity)

```txt
... msg="Created new client token: s.ZhWVveQFxHs1btla6J1VpCVa"
... msg="Check lookup-self for token ttl: 5, period: 6"
... msg="Check lookup-self for token ttl: 4, period: 6"
... msg="Check lookup-self for token ttl: 3, period: 6"
... msg="successfully renewed token s.ZhWVveQFxHs1btla6J1VpCVa"
...
... msg="Time is up!"
... msg="Report: Token refreshed as expected with a total time window of 12s, and period of 6s there were 3 token refreshes."
```

Fixes issue #34 


Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>