### PR TITLE
fix BuildURL() in SecretConfig to return url to the secret provider

### DIFF
--- a/pkg/client.go
+++ b/pkg/client.go
@@ -19,14 +19,16 @@ package pkg
 // SecretClient provides a contract for storing and retrieving secrets from a secret store provider.
 type SecretClient interface {
 	// GetSecrets retrieves secrets from a secret store.
-	// path specifies the type or location of the secrets to retrieve.
+	// path specifies the type or location of the secrets to retrieve. If specified it is appended
+	// to the base path from the SecretConfig
 	// keys specifies the secrets which to retrieve. If no keys are provided then all the keys associated with the
 	// specified path will be returned.
-	GetSecrets(path string, keys ...string) (map[string]string, error)
+	GetSecrets(subPath string, keys ...string) (map[string]string, error)
 
 	// StoreSecrets stores the secrets to a secret store.
 	// it sets the values requested at provided keys
-	// path specifies the type or location of the secrets to store
+	// path specifies the type or location of the secrets to store. If specified it is appended
+	// to the base path from the SecretConfig
 	// secrets map specifies the "key": "value" pairs of secrets to store
-	StoreSecrets(path string, secrets map[string]string) error
+	StoreSecrets(subPath string, secrets map[string]string) error
 }

--- a/pkg/providers/vault/config.go
+++ b/pkg/providers/vault/config.go
@@ -22,8 +22,9 @@ import (
 
 // SecretConfig contains configuration settings used to communicate with an HTTP based secret provider
 type SecretConfig struct {
-	Host                    string
-	Port                    int
+	Host string
+	Port int
+	// Path is the base path to the secret's location in the secret store
 	Path                    string
 	Protocol                string
 	Namespace               string
@@ -36,8 +37,13 @@ type SecretConfig struct {
 }
 
 // BuildURL constructs a URL which can be used to identify a HTTP based secret provider
-func (c SecretConfig) BuildURL() (path string) {
-	return fmt.Sprintf("%s://%s:%v%s", c.Protocol, c.Host, c.Port, c.Path)
+func (c SecretConfig) BuildURL(path string) (url string) {
+	return fmt.Sprintf("%s://%s:%v%s", c.Protocol, c.Host, c.Port, path)
+}
+
+// BuildSecretsPathURL constructs a URL which can be used to identify a secret's path
+func (c SecretConfig) BuildSecretsPathURL() (path string) {
+	return c.BuildURL(c.Path)
 }
 
 // AuthenticationInfo contains authentication information to be used when communicating with an HTTP based provider

--- a/pkg/providers/vault/config_test.go
+++ b/pkg/providers/vault/config_test.go
@@ -32,7 +32,7 @@ func TestBuildUrl(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			val := tt.cfg.BuildURL()
+			val := tt.cfg.BuildURL(tt.cfg.Path)
 			if val != tt.path {
 				t.Errorf("%s unexpected path %s", tt.name, val)
 			}


### PR DESCRIPTION
initially it returned the path to the secrets in the secret store
BuildSecretsPathURL() added to return path to the secrets in the secret store

Closes: #49

Signed-off-by: Enobong Udoko <enobong.n.udoko@intel.com>