### PR TITLE
fix BuildURL() in SecretConfig to return url to the secret provider

### DIFF
--- a/pkg/client.go
+++ b/pkg/client.go
@@ -19,14 +19,16 @@ package pkg
 // SecretClient provides a contract for storing and retrieving secrets from a secret store provider.
 type SecretClient interface {
 	// GetSecrets retrieves secrets from a secret store.
-	// path specifies the type or location of the secrets to retrieve.
+	// subPath specifies the type or location of the secrets to retrieve. If specified it is appended
+	// to the base path from the SecretConfig
 	// keys specifies the secrets which to retrieve. If no keys are provided then all the keys associated with the
 	// specified path will be returned.
-	GetSecrets(path string, keys ...string) (map[string]string, error)
+	GetSecrets(subPath string, keys ...string) (map[string]string, error)
 
 	// StoreSecrets stores the secrets to a secret store.
 	// it sets the values requested at provided keys
-	// path specifies the type or location of the secrets to store
+	// subPath specifies the type or location of the secrets to store. If specified it is appended
+	// to the base path from the SecretConfig
 	// secrets map specifies the "key": "value" pairs of secrets to store
-	StoreSecrets(path string, secrets map[string]string) error
+	StoreSecrets(subPath string, secrets map[string]string) error
 }

--- a/pkg/providers/vault/client.go
+++ b/pkg/providers/vault/client.go
@@ -148,7 +148,11 @@ func (c Client) doTokenRefreshPeriodically(renewInterval time.Duration,
 
 func (c Client) getTokenLookupResponseData() (*TokenLookupResponse, error) {
 	// call Vault's token self lookup API
-	url := c.HttpConfig.BuildURL() + lookupSelfVaultAPI
+	url, err := c.HttpConfig.BuildURL(lookupSelfVaultAPI)
+	if err != nil {
+		return nil, err
+	}
+
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
@@ -185,7 +189,11 @@ func (c Client) getTokenLookupResponseData() (*TokenLookupResponse, error) {
 
 func (c Client) renewToken() error {
 	// call Vault's renew self API
-	url := c.HttpConfig.BuildURL() + renewSelfVaultAPI
+	url, err := c.HttpConfig.BuildURL(renewSelfVaultAPI)
+	if err != nil {
+		return err
+	}
+
 	req, err := http.NewRequest(http.MethodPost, url, nil)
 	if err != nil {
 		return err
@@ -210,8 +218,8 @@ func (c Client) renewToken() error {
 	return nil
 }
 
-// GetSecrets retrieves the secrets at the provided path that match the specified keys.
-func (c Client) GetSecrets(path string, keys ...string) (map[string]string, error) {
+// GetSecrets retrieves the secrets at the provided subpath that matches the specified keys.
+func (c Client) GetSecrets(subPath string, keys ...string) (map[string]string, error) {
 	data := make(map[string]string)
 	var err error
 	addRetryAttempts := c.HttpConfig.AdditionalRetryAttempts
@@ -220,7 +228,7 @@ func (c Client) GetSecrets(path string, keys ...string) (map[string]string, erro
 		return nil, pkg.NewErrSecretStore(fmt.Sprintf("invalid retry attempts setting %d", addRetryAttempts))
 	case addRetryAttempts == 0:
 		// no retries
-		data, err = c.getAllKeys(path)
+		data, err = c.getAllKeys(subPath)
 		if err != nil {
 			return nil, err
 		}
@@ -228,12 +236,12 @@ func (c Client) GetSecrets(path string, keys ...string) (map[string]string, erro
 		// do some retries
 		// note the limit is 1 + additional retry attempts, cause we always need
 		// to do the first try
-		data, err = c.getAllKeys(path)
+		data, err = c.getAllKeys(subPath)
 
 		for tryNum := 1; err != nil && tryNum < 1+addRetryAttempts; tryNum++ {
 			time.Sleep(c.HttpConfig.retryWaitPeriodTime)
 
-			data, err = c.getAllKeys(path)
+			data, err = c.getAllKeys(subPath)
 		}
 
 		// since we finished the above loop, then check if the last iteration
@@ -268,9 +276,13 @@ func (c Client) GetSecrets(path string, keys ...string) (map[string]string, erro
 	return values, nil
 }
 
-// getAllKeys obtains all the keys that reside at the provided path.
-func (c Client) getAllKeys(path string) (map[string]string, error) {
-	url := c.HttpConfig.BuildURL() + path
+// getAllKeys obtains all the keys that reside at the provided subpath.
+func (c Client) getAllKeys(subPath string) (map[string]string, error) {
+	url, err := c.HttpConfig.BuildSecretsPathURL(subPath)
+	if err != nil {
+		return nil, err
+	}
+
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
@@ -300,7 +312,7 @@ func (c Client) getAllKeys(path string) (map[string]string, error) {
 
 	data, success := result["data"].(map[string]interface{})
 	if !success || len(data) <= 0 {
-		return nil, pkg.NewErrSecretStore(fmt.Sprintf("No secrets are present at the path: '%s'", path))
+		return nil, pkg.NewErrSecretStore(fmt.Sprintf("No secrets are present at the subpath: '%s'", subPath))
 	}
 
 	// Cast the secret values to strings
@@ -350,7 +362,8 @@ func createHTTPClient(config SecretConfig) (Caller, error) {
 	}, nil
 }
 
-func (c Client) StoreSecrets(path string, secrets map[string]string) error {
+// StoreSecrets stores the secrets at the provided subpath for the specified keys.
+func (c Client) StoreSecrets(subPath string, secrets map[string]string) error {
 
 	var err error
 	addRetryAttempts := c.HttpConfig.AdditionalRetryAttempts
@@ -359,30 +372,33 @@ func (c Client) StoreSecrets(path string, secrets map[string]string) error {
 		err = pkg.NewErrSecretStore(fmt.Sprintf("invalid retry attempts setting %d", addRetryAttempts))
 	case addRetryAttempts == 0:
 		// no retries
-		err = c.store(path, secrets)
+		err = c.store(subPath, secrets)
 	case addRetryAttempts > 0:
 		// do some retries
 		// note the limit is 1 + additional retry attempts, cause we always need
 		// to do the first try
-		err = c.store(path, secrets)
+		err = c.store(subPath, secrets)
 
 		for tryNum := 1; err != nil && tryNum < 1+addRetryAttempts; tryNum++ {
 			time.Sleep(c.HttpConfig.retryWaitPeriodTime)
 
-			err = c.store(path, secrets)
+			err = c.store(subPath, secrets)
 		}
 	}
 
 	return err
 }
 
-func (c Client) store(path string, secrets map[string]string) error {
+func (c Client) store(subPath string, secrets map[string]string) error {
 	if len(secrets) == 0 {
 		// nothing to store
 		return nil
 	}
 
-	url := c.HttpConfig.BuildURL() + path
+	url, err := c.HttpConfig.BuildSecretsPathURL(subPath)
+	if err != nil {
+		return err
+	}
 
 	payload, err := json.Marshal(secrets)
 	if err != nil {

--- a/pkg/providers/vault/config.go
+++ b/pkg/providers/vault/config.go
@@ -17,13 +17,15 @@ package vault
 
 import (
 	"fmt"
+	"net/url"
 	"time"
 )
 
 // SecretConfig contains configuration settings used to communicate with an HTTP based secret provider
 type SecretConfig struct {
-	Host                    string
-	Port                    int
+	Host string
+	Port int
+	// Path is the base path to the secret's location in the secret store
 	Path                    string
 	Protocol                string
 	Namespace               string
@@ -36,8 +38,21 @@ type SecretConfig struct {
 }
 
 // BuildURL constructs a URL which can be used to identify a HTTP based secret provider
-func (c SecretConfig) BuildURL() (path string) {
-	return fmt.Sprintf("%s://%s:%v%s", c.Protocol, c.Host, c.Port, c.Path)
+func (c SecretConfig) BuildURL(path string) (spURL string, err error) {
+	rawurl := fmt.Sprintf("%s://%s:%v%s", c.Protocol, c.Host, c.Port, path)
+
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		return "", err
+	}
+
+	return u.String(), nil
+}
+
+// BuildSecretsPathURL constructs a URL which can be used to identify a secret's path
+// subPath is the location of the secrets in the secrets engine
+func (c SecretConfig) BuildSecretsPathURL(subPath string) (url string, err error) {
+	return c.BuildURL(c.Path + subPath)
 }
 
 // AuthenticationInfo contains authentication information to be used when communicating with an HTTP based provider

--- a/pkg/providers/vault/config_test.go
+++ b/pkg/providers/vault/config_test.go
@@ -16,6 +16,8 @@ package vault
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBuildUrl(t *testing.T) {
@@ -32,10 +34,27 @@ func TestBuildUrl(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			val := tt.cfg.BuildURL()
+			val, _ := tt.cfg.BuildURL(tt.cfg.Path)
 			if val != tt.path {
 				t.Errorf("%s unexpected path %s", tt.name, val)
 			}
+		})
+	}
+}
+
+func TestBuildUrlInvalidPath(t *testing.T) {
+	cfgWithInvalidPath := SecretConfig{Host: "localhost", Port: 8080, Protocol: "http", Path: "%$bar"}
+
+	tests := []struct {
+		name string
+		cfg  SecretConfig
+	}{
+		{"invalidPath", cfgWithInvalidPath},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.cfg.BuildURL(tt.cfg.Path)
+			assert.NotEqual(t, nil, err)
 		})
 	}
 }


### PR DESCRIPTION
initially it returned the path to the secrets in the secret store
BuildSecretsPathURL() added to return path to the secrets in the secret store

Closes: #49

Signed-off-by: Enobong Udoko <enobong.n.udoko@intel.com>