### PR TITLE
build: update to go 1.15

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-ARG BASE=golang:1.13-alpine
+ARG BASE=golang:1.15-alpine
 FROM ${BASE}
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,5 @@
 //
 
 edgeXBuildGoMod (
-    project: 'go-mod-secrets',
-    goVersion: '1.13'
+    project: 'go-mod-secrets'
 )

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/edgexfoundry/go-mod-secrets
 
 require github.com/stretchr/testify v1.3.0
 
-go 1.13
+go 1.15


### PR DESCRIPTION
Updated Dockerfile, go.mod for Go 1.15

Removed go reference in Jenkinsfile so it defaults to CI/CD pipeline default

Fixes: #54
Signed-off-by: Jim White <jpwhite_mn@yahoo.com>

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:  upgrade module to Go 1.15

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
n/a

Issue Number: #54 

## What is the new behavior?
none

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information