### PR TITLE
fix: Remove trailing slash from vault URL to avoid 400 error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/edgexfoundry/go-mod-secrets
 
-require github.com/stretchr/testify v1.3.0
+require (
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.80
+	github.com/stretchr/testify v1.5.1
+)
 
 go 1.15

--- a/pkg/providers/vault/client.go
+++ b/pkg/providers/vault/client.go
@@ -283,6 +283,8 @@ func (c Client) getAllKeys(subPath string) (map[string]string, error) {
 		return nil, err
 	}
 
+	c.lc.Debug(fmt.Sprintf("Using Secrets URL of `%s`", url))
+
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
@@ -399,6 +401,8 @@ func (c Client) store(subPath string, secrets map[string]string) error {
 	if err != nil {
 		return err
 	}
+
+	c.lc.Debug(fmt.Sprintf("Using Secrets URL of `%s`", url))
 
 	payload, err := json.Marshal(secrets)
 	if err != nil {

--- a/pkg/providers/vault/client_test.go
+++ b/pkg/providers/vault/client_test.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-secrets/pkg"
 )
 
@@ -401,6 +402,7 @@ func TestHttpSecretStoreManager_GetValue(t *testing.T) {
 			ssm := Client{
 				HttpConfig: cfgHTTP,
 				HttpCaller: test.caller,
+				lc:         logger.NewClientStdOut("unit-tests", false, "DEBUG"),
 			}
 
 			actual, err := ssm.GetSecrets(test.path, test.keys...)
@@ -596,6 +598,7 @@ func TestHttpSecretStoreManager_SetValue(t *testing.T) {
 			ssm := Client{
 				HttpConfig: cfgHTTP,
 				HttpCaller: test.caller,
+				lc:         logger.NewClientStdOut("unit-tests", false, "DEBUG"),
 			}
 
 			err := ssm.StoreSecrets(test.path, test.secrets)

--- a/pkg/providers/vault/config.go
+++ b/pkg/providers/vault/config.go
@@ -18,6 +18,7 @@ package vault
 import (
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -39,6 +40,11 @@ type SecretConfig struct {
 
 // BuildURL constructs a URL which can be used to identify a HTTP based secret provider
 func (c SecretConfig) BuildURL(path string) (spURL string, err error) {
+	// Make sure there is not a trailing slash
+	if strings.HasSuffix(path, "/") {
+		path = path[:len(path)-1]
+	}
+
 	rawurl := fmt.Sprintf("%s://%s:%v%s", c.Protocol, c.Host, c.Port, path)
 
 	u, err := url.Parse(rawurl)

--- a/pkg/providers/vault/config_test.go
+++ b/pkg/providers/vault/config_test.go
@@ -23,6 +23,7 @@ import (
 func TestBuildUrl(t *testing.T) {
 	cfgNoPath := SecretConfig{Host: "localhost", Port: 8080, Protocol: "http"}
 	cfgWithPath := SecretConfig{Host: "localhost", Port: 8080, Protocol: "http", Path: "/ping"}
+	cfgWithTrailingSlash := SecretConfig{Host: "localhost", Port: 8080, Protocol: "http", Path: "/api/v1/ping/"}
 
 	tests := []struct {
 		name string
@@ -31,6 +32,7 @@ func TestBuildUrl(t *testing.T) {
 	}{
 		{"validNoPath", cfgNoPath, "http://localhost:8080"},
 		{"validWithPath", cfgWithPath, "http://localhost:8080/ping"},
+		{"validWithTrailingSlash", cfgWithTrailingSlash, "http://localhost:8080/api/v1/ping"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Paths with trailing slash are sent to Vault

Issue Number: #56


## What is the new behavior?
Trailing slash if exists is removed when build Vault URL

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information