### PR TITLE
refactor: Resolve compiler errors in unit test when using latest go-mod-core-contracts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/edgexfoundry/go-mod-secrets
 
 require (
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.129
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.136
 	github.com/stretchr/testify v1.6.1
 )
 

--- a/pkg/providers/vault/client_test.go
+++ b/pkg/providers/vault/client_test.go
@@ -26,10 +26,10 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/edgexfoundry/go-mod-secrets/pkg"
 	"github.com/edgexfoundry/go-mod-secrets/pkg/types"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	"github.com/edgexfoundry/go-mod-secrets/pkg"
 )
 
 var TestPath = "/data"
@@ -327,7 +327,7 @@ func TestHttpSecretStoreManager_GetValue(t *testing.T) {
 			ssm := Client{
 				HttpConfig: cfgHTTP,
 				HttpCaller: test.caller,
-				lc:         logger.NewClientStdOut("unit-tests", false, "DEBUG"),
+				lc:         logger.NewMockClient(),
 			}
 
 			actual, err := ssm.GetSecrets(test.path, test.keys...)
@@ -523,7 +523,7 @@ func TestHttpSecretStoreManager_SetValue(t *testing.T) {
 			ssm := Client{
 				HttpConfig: cfgHTTP,
 				HttpCaller: test.caller,
-				lc:         logger.NewClientStdOut("unit-tests", false, "DEBUG"),
+				lc:         logger.NewMockClient(),
 			}
 
 			err := ssm.StoreSecrets(test.path, test.secrets)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Unit tests use logger factory method that has been removed in latest go-mod-core-contracts

Issue Number:  #76


## What is the new behavior?
Unit tests now use logger.NewMockClient()

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information