### PR TITLE
refactor: Consume V2 go-mod-secrets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/edgexfoundry/go-mod-secrets/v2
 
 require (
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.146
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.1
 	github.com/stretchr/testify v1.6.1
 )
 

--- a/pkg/providers/vault/client.go
+++ b/pkg/providers/vault/client.go
@@ -26,9 +26,10 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-secrets/v2/pkg"
 	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/types"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 )
 
 const (

--- a/pkg/providers/vault/client_test.go
+++ b/pkg/providers/vault/client_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/edgexfoundry/go-mod-secrets/v2/pkg"
 	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/types"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 )
 
 var TestPath = "/data"

--- a/secrets/factory.go
+++ b/secrets/factory.go
@@ -19,10 +19,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-secrets/v2/pkg"
 	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/providers/vault"
 	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/types"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 )
 
 func NewClient(ctx context.Context, config types.SecretConfig, lc logger.LoggingClient, callback pkg.TokenExpiredCallback) (SecretClient, error) {

--- a/secrets/factory_test.go
+++ b/secrets/factory_test.go
@@ -14,10 +14,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-secrets/v2/pkg"
 	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/providers/vault"
 	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/types"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 )
 
 func TestNewSecretClient(t *testing.T) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Consuming V0 Go Module version of go-mod-secrets

Issue Number:  #81


## What is the new behavior?
Now consume V2 Go Module version of go-mod-secrets


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information