### PR TITLE
feat: Add GenerateConsulToken API to SecretClient interface

### DIFF
--- a/internal/pkg/vault/management.go
+++ b/internal/pkg/vault/management.go
@@ -204,7 +204,12 @@ func (c *Client) CheckSecretEngineInstalled(token string, mountPoint string, eng
 // the serviceKey is used in the part of secretstore's URL as role name and should be accessible to the API
 func (c *Client) GenerateConsulToken(mgmtToken, serviceKey string) (string, error) {
 	if len(mgmtToken) == 0 {
-		return emptyToken, pkg.NewErrSecretStore("missing mgmt token for generating Consul token")
+		// If mgmtToken, assume using service's own token.
+		mgmtToken = c.Config.Authentication.AuthToken
+
+		if len(mgmtToken) == 0 {
+			return emptyToken, pkg.NewErrSecretStore("missing mgmt token for generating Consul token")
+		}
 	}
 
 	trimmedSrvKey := strings.TrimSpace(serviceKey)

--- a/pkg/listener/poll_test.go
+++ b/pkg/listener/poll_test.go
@@ -101,6 +101,10 @@ func (mssm MockSecretClient) GetTokenDetails() (*types.TokenMetadata, error) {
 	return nil, nil
 }
 
+func (mssm MockSecretClient) GenerateConsulToken(token, serviceKey string) (string, error) {
+	panic("GenerateConsulToken not implemented")
+}
+
 func TestGetKeys(t *testing.T) {
 	testClient := newTestMockSecretClient()
 	tests := []struct {

--- a/secrets/interfaces.go
+++ b/secrets/interfaces.go
@@ -34,6 +34,15 @@ type SecretClient interface {
 	// to the base path from the SecretConfig
 	// secrets map specifies the "key": "value" pairs of secrets to store
 	StoreSecrets(subPath string, secrets map[string]string) error
+
+	// GenerateConsulToken generates a new Consul token based on the given serviceKey
+	// it requires a secret store token with the permission to generate a Consul token
+	// the Consul token is like a bearer token and is used to access the information from Consul
+	// like service's configuration in key/value store of Consul
+	// the generated token is unique every time
+	// caller should persist or cache the generated Consul token, at least per runtime cycle, to reduce the number of
+	// tokens stored in Consul server side and the number of calls to this API
+	GenerateConsulToken(token, serviceKey string) (string, error)
 }
 
 // SecretStoreClient provides a contract for managing a Secret Store from a secret store provider.

--- a/secrets/mocks/SecretClient.go
+++ b/secrets/mocks/SecretClient.go
@@ -9,6 +9,27 @@ type SecretClient struct {
 	mock.Mock
 }
 
+// GenerateConsulToken provides a mock function with given fields: token, serviceKey
+func (_m *SecretClient) GenerateConsulToken(token string, serviceKey string) (string, error) {
+	ret := _m.Called(token, serviceKey)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string, string) string); ok {
+		r0 = rf(token, serviceKey)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(token, serviceKey)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetSecrets provides a mock function with given fields: subPath, keys
 func (_m *SecretClient) GetSecrets(subPath string, keys ...string) (map[string]string, error) {
 	_va := make([]interface{}, len(keys))


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
`SecretClient` interface doesn't contain `GenerateConsulToken`
Implementation exists, just needs to be exposed through SecretClient interface

Issue Number: #100

## What is the new behavior?
`SecretClient` interface now contains `GenerateConsulToken`

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information