### PR TITLE
fix(security): Fix JSON structure of token self response

### DIFF
--- a/internal/pkg/vault/secrets.go
+++ b/internal/pkg/vault/secrets.go
@@ -197,7 +197,8 @@ func (c *Client) getTokenDetails() (*types.TokenMetadata, error) {
 		}
 	}
 
-	result := types.TokenMetadata{}
+	// the returned JSON structure for token self-read is TokenLookupResponse
+	result := TokenLookupResponse{}
 	jsonDec := json.NewDecoder(resp.Body)
 	if jsonDec == nil {
 		return nil, pkg.NewErrSecretStore("failed to obtain json decoder")
@@ -208,7 +209,7 @@ func (c *Client) getTokenDetails() (*types.TokenMetadata, error) {
 		return nil, err
 	}
 
-	return &result, nil
+	return &result.Data, nil
 }
 
 func (c *Client) refreshToken(ctx context.Context, tokenExpiredCallback pkg.TokenExpiredCallback) error {
@@ -228,7 +229,7 @@ func (c *Client) refreshToken(ctx context.Context, tokenExpiredCallback pkg.Toke
 	tokenPeriod := time.Duration(tokenData.Period) * time.Second
 	renewInterval := tokenPeriod / 2
 	if renewInterval <= 0 {
-		// no renew
+		// cannot renew, as the renew interval is non-positive
 		c.lc.Warn("no token renewal since renewInterval is 0")
 		return nil
 	}

--- a/internal/pkg/vault/secrets_test.go
+++ b/internal/pkg/vault/secrets_test.go
@@ -51,10 +51,12 @@ const (
 func TestNewSecretsClient(t *testing.T) {
 	authToken := "testToken"
 	var tokenDataMap sync.Map
-	tokenDataMap.Store(authToken, types.TokenMetadata{
-		Renewable: true,
-		Ttl:       10000,
-		Period:    10000,
+	tokenDataMap.Store(authToken, TokenLookupResponse{
+		Data: types.TokenMetadata{
+			Renewable: true,
+			Ttl:       10000,
+			Period:    10000,
+		},
 	})
 	server := GetMockTokenServer(&tokenDataMap)
 	defer server.Close()
@@ -114,40 +116,52 @@ func TestMultipleTokenRenewals(t *testing.T) {
 	tokenPeriod := 6
 	var tokenDataMap sync.Map
 	// ttl > half of period
-	tokenDataMap.Store("testToken1", types.TokenMetadata{
-		Renewable: true,
-		Ttl:       tokenPeriod * 7 / 10,
-		Period:    tokenPeriod,
+	tokenDataMap.Store("testToken1", TokenLookupResponse{
+		Data: types.TokenMetadata{
+			Renewable: true,
+			Ttl:       tokenPeriod * 7 / 10,
+			Period:    tokenPeriod,
+		},
 	})
 	// ttl = half of period
-	tokenDataMap.Store("testToken2", types.TokenMetadata{
-		Renewable: true,
-		Ttl:       tokenPeriod / 2,
-		Period:    tokenPeriod,
+	tokenDataMap.Store("testToken2", TokenLookupResponse{
+		Data: types.TokenMetadata{
+			Renewable: true,
+			Ttl:       tokenPeriod / 2,
+			Period:    tokenPeriod,
+		},
 	})
 	// ttl < half of period
-	tokenDataMap.Store("testToken3", types.TokenMetadata{
-		Renewable: true,
-		Ttl:       tokenPeriod * 3 / 10,
-		Period:    tokenPeriod,
+	tokenDataMap.Store("testToken3", TokenLookupResponse{
+		Data: types.TokenMetadata{
+			Renewable: true,
+			Ttl:       tokenPeriod * 3 / 10,
+			Period:    tokenPeriod,
+		},
 	})
 	// to be expired token
-	tokenDataMap.Store("toToExpiredToken", types.TokenMetadata{
-		Renewable: true,
-		Ttl:       1,
-		Period:    tokenPeriod,
+	tokenDataMap.Store("toToExpiredToken", TokenLookupResponse{
+		Data: types.TokenMetadata{
+			Renewable: true,
+			Ttl:       1,
+			Period:    tokenPeriod,
+		},
 	})
 	// expired token
-	tokenDataMap.Store("expiredToken", types.TokenMetadata{
-		Renewable: true,
-		Ttl:       0,
-		Period:    tokenPeriod,
+	tokenDataMap.Store("expiredToken", TokenLookupResponse{
+		Data: types.TokenMetadata{
+			Renewable: true,
+			Ttl:       0,
+			Period:    tokenPeriod,
+		},
 	})
 	// not renewable token
-	tokenDataMap.Store("unrenewableToken", types.TokenMetadata{
-		Renewable: false,
-		Ttl:       0,
-		Period:    tokenPeriod,
+	tokenDataMap.Store("unrenewableToken", TokenLookupResponse{
+		Data: types.TokenMetadata{
+			Renewable: false,
+			Ttl:       0,
+			Period:    tokenPeriod,
+		},
 	})
 
 	server := GetMockTokenServer(&tokenDataMap)
@@ -263,7 +277,7 @@ func TestMultipleTokenRenewals(t *testing.T) {
 			if lookupTokenData != nil && lookupTokenData.Renewable &&
 				lookupTokenData.Ttl < tokenPeriod/2 {
 				tokenData, _ := tokenDataMap.Load(test.authToken)
-				tokenTTL := tokenData.(types.TokenMetadata).Ttl
+				tokenTTL := tokenData.(TokenLookupResponse).Data.Ttl
 				t.Errorf("failed to renew token with the token period %d: the current TTL %d and the old TTL: %d",
 					tokenPeriod, lookupTokenData.Ttl, tokenTTL)
 			}
@@ -281,10 +295,12 @@ func TestMultipleClientsFailureCase(t *testing.T) {
 	var tokenDataMap sync.Map
 
 	// expired token
-	tokenDataMap.Store("expiredToken", types.TokenMetadata{
-		Renewable: true,
-		Ttl:       0,
-		Period:    tokenPeriod,
+	tokenDataMap.Store("expiredToken", TokenLookupResponse{
+		Data: types.TokenMetadata{
+			Renewable: true,
+			Ttl:       0,
+			Period:    tokenPeriod,
+		},
 	})
 
 	server := GetMockTokenServer(&tokenDataMap)
@@ -329,10 +345,12 @@ func TestConcurrentSecretClientTokenRenewals(t *testing.T) {
 	var tokenDataMap sync.Map
 
 	// ttl < half of period
-	tokenDataMap.Store("testToken3", types.TokenMetadata{
-		Renewable: true,
-		Ttl:       tokenPeriod * 3 / 10,
-		Period:    tokenPeriod,
+	tokenDataMap.Store("testToken3", TokenLookupResponse{
+		Data: types.TokenMetadata{
+			Renewable: true,
+			Ttl:       tokenPeriod * 3 / 10,
+			Period:    tokenPeriod,
+		},
 	})
 
 	server := GetMockTokenServer(&tokenDataMap)

--- a/pkg/types/messages.go
+++ b/pkg/types/messages.go
@@ -26,7 +26,8 @@ type InitResponse struct {
 	RootToken     string   `json:"root_token,omitempty"`
 }
 
-// TokenMetadata has introspection data about a token
+// TokenMetadata has introspection data about a token and is the "data" sub-structure for token lookup,
+// i.e. TokenLookupResponse, and token self-lookup
 type TokenMetadata struct {
 	Accessor   string   `json:"accessor"`
 	ExpireTime string   `json:"expire_time"`

--- a/secrets/factory_test.go
+++ b/secrets/factory_test.go
@@ -37,10 +37,12 @@ func TestNewSecretsClient(t *testing.T) {
 	tokenPeriod := 6
 	var tokenDataMap sync.Map
 	// ttl > half of period
-	tokenDataMap.Store("TestToken", types.TokenMetadata{
-		Renewable: true,
-		Ttl:       tokenPeriod * 7 / 10,
-		Period:    tokenPeriod,
+	tokenDataMap.Store("TestToken", vault.TokenLookupResponse{
+		Data: types.TokenMetadata{
+			Renewable: true,
+			Ttl:       tokenPeriod * 7 / 10,
+			Period:    tokenPeriod,
+		},
 	})
 
 	server := vault.GetMockTokenServer(&tokenDataMap)


### PR DESCRIPTION
Fix the issue as to token-self lookup API response returning `TokenMetadata` and it should be wrapped inside `"data"` JSON sub-structure

Closes: #102
Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x ] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Currently, the token-self uses the wrong JSON structure information

Issue Number: #102 


## What is the new behavior?
Fix the JSON structure for token-self lookup to use the right JSON structure information and also fix the unit tests.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information