### PR TITLE
refactor!: clean up retry code for GetSecrets and StoreSecrets APIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@
 
 .PHONY: test
 
-GO=CGO_ENABLED=0 GO111MODULE=on go
+GO=CGO_ENABLED=1 GO111MODULE=on go
 
 test:
-	$(GO) test ./... -coverprofile=coverage.out
+	$(GO) test -count=1 -race ./... -coverprofile=coverage.out
 	$(GO) vet ./...
 	gofmt -l .
 	[ "`gofmt -l .`" = "" ]

--- a/internal/pkg/vault/client.go
+++ b/internal/pkg/vault/client.go
@@ -21,7 +21,6 @@ import (
 	"crypto/x509"
 	"io/ioutil"
 	"net/http"
-	"time"
 
 	"github.com/edgexfoundry/go-mod-secrets/v2/pkg"
 	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/types"
@@ -53,14 +52,6 @@ func NewClient(config types.SecretConfig, requester pkg.Caller, forSecrets bool,
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	if config.RetryWaitPeriod != "" {
-		retryTimeDuration, err := time.ParseDuration(config.RetryWaitPeriod)
-		if err != nil {
-			return nil, err
-		}
-		config.RetryWaitPeriodTime = retryTimeDuration
 	}
 
 	vaultClient := Client{

--- a/internal/pkg/vault/client_test.go
+++ b/internal/pkg/vault/client_test.go
@@ -31,12 +31,9 @@ func TestNewClient(t *testing.T) {
 		Authentication: types.AuthenticationInfo{
 			AuthToken: "my-unit-test-token",
 		},
-		RetryWaitPeriod: "1ms",
 	}
 	noToken := validConfig
 	noToken.Authentication.AuthToken = ""
-	badWaitPeriod := validConfig
-	badWaitPeriod.RetryWaitPeriod = "n/a"
 
 	tests := []struct {
 		Name        string
@@ -45,7 +42,6 @@ func TestNewClient(t *testing.T) {
 	}{
 		{"Valid", validConfig, false},
 		{"Invalid - no token", noToken, true},
-		{"Invalid - bad wait period", badWaitPeriod, true},
 	}
 
 	for _, test := range tests {

--- a/internal/pkg/vault/management_test.go
+++ b/internal/pkg/vault/management_test.go
@@ -436,11 +436,10 @@ func createClient(t *testing.T, url string, lc logger.LoggingClient) *Client {
 	require.NoError(t, err)
 
 	config := types.SecretConfig{
-		Type:            "vault",
-		Protocol:        urlDetails.Scheme,
-		Host:            urlDetails.Hostname(),
-		Port:            port,
-		RetryWaitPeriod: "1s",
+		Type:     "vault",
+		Protocol: urlDetails.Scheme,
+		Host:     urlDetails.Hostname(),
+		Port:     port,
 	}
 
 	client, err := NewClient(config, pkg.NewMockRequester().Insecure(), false, lc)

--- a/pkg/listener/poll.go
+++ b/pkg/listener/poll.go
@@ -59,7 +59,7 @@ func NewInMemoryCacheListener(client secrets.SecretClient, updateChan chan map[s
 		keys:              keys,
 		updaterChan:       updateChan,
 		errorChan:         errorChan,
-		stopChan:          make(chan struct{}),
+		stopChan:          make(chan struct{}, 10),
 		backoffPattern:    backoffPattern,
 		isRunning:         false,
 		timerFunc:         time.NewTimer,

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
-	"time"
 )
 
 // SecretConfig contains configuration settings used to communicate with an HTTP based secret provider
@@ -28,15 +27,12 @@ type SecretConfig struct {
 	Host string
 	Port int
 	// Path is the base path to the secret's location in the secret store
-	Path                    string
-	Protocol                string
-	Namespace               string
-	RootCaCertPath          string
-	ServerName              string
-	Authentication          AuthenticationInfo
-	AdditionalRetryAttempts int
-	RetryWaitPeriod         string
-	RetryWaitPeriodTime     time.Duration
+	Path           string
+	Protocol       string
+	Namespace      string
+	RootCaCertPath string
+	ServerName     string
+	Authentication AuthenticationInfo
 }
 
 // BuildURL constructs a URL which can be used to identify a HTTP based secret provider

--- a/secrets/factory_test.go
+++ b/secrets/factory_test.go
@@ -75,7 +75,6 @@ func TestNewSecretsClient(t *testing.T) {
 				Authentication: types.AuthenticationInfo{
 					AuthToken: "TestToken",
 				},
-				RetryWaitPeriod: "1s",
 			}
 
 			client, err := NewSecretsClient(test.Ctx, config, mockLogger, nil)


### PR DESCRIPTION
Remove all codes related to retry attempts

Fixes: #115

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
unnecessary retry code in the current GetSecrets and StoreSecrets API implementation

Issue Number: #115 


## What is the new behavior?
Remove these retry code from both GetSecrets and StoreSecrets APIs

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x ] Yes
- [ ] No

**The configuration entries: 
`AdditionalRetryAttempts`, `RetryWaitPeriod`, `RetryWaitPeriodTime`  got removed and thus all services use these items will need to modify their code; for example, all SecretStore configuration under core services in `edgex-go`.**

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information