### PR TITLE
fix: close response Body when the returned error is nil

### DIFF
--- a/internal/pkg/vault/secrets.go
+++ b/internal/pkg/vault/secrets.go
@@ -370,14 +370,13 @@ func (c *Client) getAllKeys(subPath string) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return nil, pkg.NewErrSecretStore(fmt.Sprintf("Received a '%d' response from the secret store", resp.StatusCode))
 	}
-
-	defer func() {
-		_ = resp.Body.Close()
-	}()
 
 	var result map[string]interface{}
 	err = json.NewDecoder(resp.Body).Decode(&result)
@@ -440,9 +439,7 @@ func (c *Client) store(subPath string, secrets map[string]string) error {
 		return err
 	}
 	defer func() {
-		if resp.Body != nil {
-			_ = resp.Body.Close()
-		}
+		_ = resp.Body.Close()
 	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {

--- a/internal/pkg/vault/secrets_test.go
+++ b/internal/pkg/vault/secrets_test.go
@@ -801,6 +801,7 @@ func (emc *ErrorMockCaller) Do(_ *http.Request) (*http.Response, error) {
 	}
 
 	return &http.Response{
+		Body:       ioutil.NopCloser(bytes.NewBufferString("")),
 		StatusCode: emc.StatusCode,
 	}, nil
 }
@@ -819,6 +820,7 @@ func (caller *InMemoryMockCaller) Do(req *http.Request) (*http.Response, error) 
 		if caller.nErrorsReturned != caller.NErrorsBeforeSuccess {
 			caller.nErrorsReturned++
 			return &http.Response{
+				Body:       ioutil.NopCloser(bytes.NewBufferString("")),
 				StatusCode: 404,
 			}, nil
 		}
@@ -831,6 +833,7 @@ func (caller *InMemoryMockCaller) Do(req *http.Request) (*http.Response, error) 
 	case http.MethodGet:
 		if req.URL.Path != testPath {
 			return &http.Response{
+				Body:       ioutil.NopCloser(bytes.NewBufferString("")),
 				StatusCode: 404,
 			}, nil
 		}
@@ -843,6 +846,7 @@ func (caller *InMemoryMockCaller) Do(req *http.Request) (*http.Response, error) 
 	case http.MethodPost:
 		if req.URL.Path != testPath {
 			return &http.Response{
+				Body:       ioutil.NopCloser(bytes.NewBufferString("")),
 				StatusCode: 404,
 			}, nil
 		}
@@ -850,6 +854,7 @@ func (caller *InMemoryMockCaller) Do(req *http.Request) (*http.Response, error) 
 		_ = json.NewDecoder(req.Body).Decode(&result)
 		caller.Result = result
 		return &http.Response{
+			Body:       ioutil.NopCloser(bytes.NewBufferString("")),
 			StatusCode: 200,
 		}, nil
 	default:


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-secrets/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->
Issue: https://github.com/edgexfoundry/go-mod-secrets/issues/145

<!-- Add additional detailed description of need for change if no related issue -->
According to this [official http client documentation](https://golang.org/pkg/net/http/#Client.Do), `If the returned error is nil, the Response will contain a non-nil Body which the user is expected to close.`. The Response Body must be closed when the returned error is nil. And we don't need check whether the Response Body is nil.

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-secrets/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->