### PR TITLE
fix: close response Body when the returned error is nil (#146)

### DIFF
--- a/internal/pkg/vault/secrets.go
+++ b/internal/pkg/vault/secrets.go
@@ -370,14 +370,13 @@ func (c *Client) getAllKeys(subPath string) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return nil, pkg.NewErrSecretStore(fmt.Sprintf("Received a '%d' response from the secret store", resp.StatusCode))
 	}
-
-	defer func() {
-		_ = resp.Body.Close()
-	}()
 
 	var result map[string]interface{}
 	err = json.NewDecoder(resp.Body).Decode(&result)
@@ -440,9 +439,7 @@ func (c *Client) store(subPath string, secrets map[string]string) error {
 		return err
 	}
 	defer func() {
-		if resp.Body != nil {
-			_ = resp.Body.Close()
-		}
+		_ = resp.Body.Close()
 	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {

--- a/internal/pkg/vault/secrets_test.go
+++ b/internal/pkg/vault/secrets_test.go
@@ -801,6 +801,7 @@ func (emc *ErrorMockCaller) Do(_ *http.Request) (*http.Response, error) {
 	}
 
 	return &http.Response{
+		Body:       ioutil.NopCloser(bytes.NewBufferString("")),
 		StatusCode: emc.StatusCode,
 	}, nil
 }
@@ -819,6 +820,7 @@ func (caller *InMemoryMockCaller) Do(req *http.Request) (*http.Response, error) 
 		if caller.nErrorsReturned != caller.NErrorsBeforeSuccess {
 			caller.nErrorsReturned++
 			return &http.Response{
+				Body:       ioutil.NopCloser(bytes.NewBufferString("")),
 				StatusCode: 404,
 			}, nil
 		}
@@ -831,6 +833,7 @@ func (caller *InMemoryMockCaller) Do(req *http.Request) (*http.Response, error) 
 	case http.MethodGet:
 		if req.URL.Path != testPath {
 			return &http.Response{
+				Body:       ioutil.NopCloser(bytes.NewBufferString("")),
 				StatusCode: 404,
 			}, nil
 		}
@@ -843,6 +846,7 @@ func (caller *InMemoryMockCaller) Do(req *http.Request) (*http.Response, error) 
 	case http.MethodPost:
 		if req.URL.Path != testPath {
 			return &http.Response{
+				Body:       ioutil.NopCloser(bytes.NewBufferString("")),
 				StatusCode: 404,
 			}, nil
 		}
@@ -850,6 +854,7 @@ func (caller *InMemoryMockCaller) Do(req *http.Request) (*http.Response, error) 
 		_ = json.NewDecoder(req.Body).Decode(&result)
 		caller.Result = result
 		return &http.Response{
+			Body:       ioutil.NopCloser(bytes.NewBufferString("")),
 			StatusCode: 200,
 		}, nil
 	default:


### PR DESCRIPTION
* fix: close response Body when the returned error is nil

Signed-off-by: gao270615179 <270615179@qq.com>

* fix: add InMemoryMockCaller response body

Signed-off-by: gao270615179 <270615179@qq.com>

Cherry pick 3ba02e4013d11d8a0b0741f59debb32a9114f29d from main

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [X] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
make test

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->