### PR TITLE
feat: Enabling hooks for Vault identity features

### DIFF
--- a/internal/pkg/vault/constants.go
+++ b/internal/pkg/vault/constants.go
@@ -36,6 +36,14 @@ const (
 	GenerateConsulTokenAPI     = "/v1/consul/creds/%s" // nolint: gosec
 	consulConfigAccessVaultAPI = "/v1/consul/config/access"
 	createConsulRoleVaultAPI   = "/v1/consul/roles/%s"
+	namedEntityAPI             = "/v1/identity/entity/name"
+	entityAliasAPI             = "/v1/identity/entity-alias"
+	oidcKeyAPI                 = "/v1/identity/oidc/key"
+	oidcRoleAPI                = "/v1/identity/oidc/role"
+	oidcGetTokenAPI            = "/v1/identity/oidc/token"      // nolint: gosec
+	oidcTokenIntrospectAPI     = "/v1/identity/oidc/introspect" // nolint: gosec
+	authAPI                    = "/v1/sys/auth"
+	authMountBase              = "/v1/auth"
 
 	lookupSelfVaultAPI = "/v1/auth/token/lookup-self"
 	renewSelfVaultAPI  = "/v1/auth/token/renew-self"

--- a/internal/pkg/vault/management.go
+++ b/internal/pkg/vault/management.go
@@ -20,6 +20,8 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"regexp"
+	"strings"
 
 	"github.com/edgexfoundry/go-mod-secrets/v3/pkg/types"
 )
@@ -178,7 +180,7 @@ func (c *Client) CheckSecretEngineInstalled(token string, mountPoint string, eng
 		Path:                 MountsAPI,
 		JSONObject:           nil,
 		BodyReader:           nil,
-		OperationDescription: "query mounts for" + engine,
+		OperationDescription: "query mounts for '" + engine + "'",
 		ExpectedStatusCode:   http.StatusOK,
 		ResponseObject:       &response,
 	})
@@ -245,5 +247,344 @@ func (c *Client) ConfigureConsulAccess(secretStoreToken string, bootstrapACLToke
 		ExpectedStatusCode:   http.StatusNoContent,
 		ResponseObject:       nil,
 	})
+	return err
+}
+
+func (c *Client) CreateOrUpdateIdentity(secretStoreToken string, name string, metadata map[string]string, policies []string) (string, error) {
+	urlPath := path.Join(namedEntityAPI, name)
+	request := CreateUpdateEntityRequest{Metadata: metadata, Policies: policies}
+	response := CreateUpdateEntityResponse{}
+
+	code, err := c.doRequest(RequestArgs{
+		AuthToken:            secretStoreToken,
+		Method:               http.MethodPost,
+		Path:                 urlPath,
+		JSONObject:           request,
+		BodyReader:           nil,
+		OperationDescription: "Create/Update Entity",
+		ExpectedStatusCode:   http.StatusOK,
+		ResponseObject:       &response,
+	})
+
+	// Update doesn't return the entity id; just return blank, look it up later
+
+	if code == http.StatusNoContent {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+
+	return response.Data.ID, nil
+}
+
+func (c *Client) DeleteIdentity(secretStoreToken string, name string) error {
+	urlPath := path.Join(namedEntityAPI, name)
+
+	_, err := c.doRequest(RequestArgs{
+		AuthToken:            secretStoreToken,
+		Method:               http.MethodDelete,
+		Path:                 urlPath,
+		JSONObject:           nil,
+		BodyReader:           nil,
+		OperationDescription: "Delete Entity",
+		ExpectedStatusCode:   http.StatusNoContent,
+		ResponseObject:       nil,
+	})
+
+	return err
+}
+
+func (c *Client) LookupIdentity(secretStoreToken string, name string) (string, error) {
+	urlPath := path.Join(namedEntityAPI, name)
+	response := ReadEntityByNameResponse{}
+
+	code, err := c.doRequest(RequestArgs{
+		AuthToken:            secretStoreToken,
+		Method:               http.MethodGet,
+		Path:                 urlPath,
+		JSONObject:           nil,
+		BodyReader:           nil,
+		OperationDescription: "Read Entity",
+		ExpectedStatusCode:   http.StatusOK,
+		ResponseObject:       &response,
+	})
+
+	// 404 is a valid response, either if there are no entities at all
+	// or if the one we are looking for isn't there
+
+	if code == http.StatusNotFound {
+		return "", nil
+	} else if err != nil {
+		return "", err
+	}
+
+	return response.Data.ID, nil
+}
+
+func (c *Client) CheckAuthMethodEnabled(token string, mountPoint string, authType string) (bool, error) {
+	var response ListSecretEnginesResponse
+
+	_, err := c.doRequest(RequestArgs{
+		AuthToken:            token,
+		Method:               http.MethodGet,
+		Path:                 authAPI,
+		JSONObject:           nil,
+		BodyReader:           nil,
+		OperationDescription: "query auth engine for " + mountPoint + " (" + authType + ")",
+		ExpectedStatusCode:   http.StatusOK,
+		ResponseObject:       &response,
+	})
+
+	if err != nil {
+		return false, err
+	}
+
+	if !strings.HasSuffix(mountPoint, "/") {
+		mountPoint += "/"
+	}
+
+	if mountData := response.Data[mountPoint]; mountData.Type == authType {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (c *Client) EnablePasswordAuth(token string, mountPoint string) error {
+	urlPath := path.Join(authAPI, mountPoint)
+	parameters := EnableAuthMethodRequest{
+		Type: UsernamePasswordAuthMethod,
+	}
+
+	_, err := c.doRequest(RequestArgs{
+		AuthToken:            token,
+		Method:               http.MethodPost,
+		Path:                 urlPath,
+		JSONObject:           parameters,
+		BodyReader:           nil,
+		OperationDescription: "Enable password auth",
+		ExpectedStatusCode:   http.StatusNoContent,
+		ResponseObject:       nil,
+	})
+
+	return err
+}
+
+func (c *Client) LookupAuthHandle(token string, mountPoint string) (string, error) {
+	response := ListAuthMethodsResponse{}
+
+	_, err := c.doRequest(RequestArgs{
+		AuthToken:            token,
+		Method:               http.MethodGet,
+		Path:                 authAPI,
+		JSONObject:           nil,
+		BodyReader:           nil,
+		OperationDescription: "List auth methods",
+		ExpectedStatusCode:   http.StatusOK,
+		ResponseObject:       &response,
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	info, ok := response.Data[mountPoint+"/"]
+	if !ok {
+		return "", fmt.Errorf("Mount point %s not found", mountPoint)
+	}
+	return info.Accessor, nil
+}
+
+func (c *Client) CreateOrUpdateUser(token string, mountPoint string, username string, password string, tokenTTL string, tokenPolicies []string) error {
+
+	const UserNameRE string = "^[-a-zA-Z0-9]+$"
+
+	re, err := regexp.Compile(UserNameRE)
+	if err != nil {
+		return err
+	}
+
+	if !re.MatchString(username) {
+		return fmt.Errorf("invalid username: %s", username)
+	}
+
+	urlPath := path.Join(authMountBase, mountPoint, "users", username)
+	parameters := CreateOrUpdateUserRequest{
+		Password:      password,
+		TokenPeriod:   tokenTTL, // setting Period means that the token is renewable indefinitely
+		TokenPolicies: tokenPolicies,
+	}
+
+	_, err = c.doRequest(RequestArgs{
+		AuthToken:            token,
+		Method:               http.MethodPost,
+		Path:                 urlPath,
+		JSONObject:           parameters,
+		BodyReader:           nil,
+		OperationDescription: "Create or update user",
+		ExpectedStatusCode:   http.StatusNoContent,
+		ResponseObject:       nil,
+	})
+
+	return err
+}
+
+func (c *Client) DeleteUser(token string, mountPoint string, username string) error {
+
+	const UserNameRE string = "^[-a-zA-Z0-9]+$"
+
+	re, err := regexp.Compile(UserNameRE)
+	if err != nil {
+		return err
+	}
+
+	if !re.MatchString(username) {
+		return fmt.Errorf("invalid username: %s", username)
+	}
+
+	urlPath := path.Join(authMountBase, mountPoint, "users", username)
+
+	_, err = c.doRequest(RequestArgs{
+		AuthToken:            token,
+		Method:               http.MethodDelete,
+		Path:                 urlPath,
+		JSONObject:           nil,
+		BodyReader:           nil,
+		OperationDescription: "Delete user",
+		ExpectedStatusCode:   http.StatusNoContent,
+		ResponseObject:       nil,
+	})
+
+	return err
+}
+
+func (c *Client) BindUserToIdentity(token string, identityId string, authHandle string, username string) error {
+	parameters := CreateEntityAliasRequest{
+		Name:          username,
+		CanonicalID:   identityId,
+		MountAccessor: authHandle,
+	}
+
+	code, err := c.doRequest(RequestArgs{
+		AuthToken:            token,
+		Method:               http.MethodPost,
+		Path:                 entityAliasAPI,
+		JSONObject:           parameters,
+		BodyReader:           nil,
+		OperationDescription: "Create entity alias (assign login to identity)",
+		ExpectedStatusCode:   http.StatusOK,
+		ResponseObject:       nil,
+	})
+
+	// If this is a duplicate bind (HTTP no content), this is also OK
+
+	if code == http.StatusNoContent {
+		return nil
+	}
+
+	return err
+}
+
+func (c *Client) InternalServiceLogin(token string, authEngine string, username string, password string) (map[string]interface{}, error) {
+	urlPath := path.Join(authMountBase, authEngine, "login", username)
+	parameters := UserPassLoginRequest{
+		Password: password,
+	}
+
+	response := make(map[string]interface{})
+
+	_, err := c.doRequest(RequestArgs{
+		AuthToken:            "", // No token required to login
+		Method:               http.MethodPost,
+		Path:                 urlPath,
+		JSONObject:           parameters,
+		BodyReader:           nil,
+		OperationDescription: "login user (service)",
+		ExpectedStatusCode:   http.StatusOK,
+		ResponseObject:       &response,
+	})
+
+	return response, err
+
+}
+
+func (c *Client) CheckIdentityKeyExists(token string, keyName string) (bool, error) {
+	response := ListNamedKeysResponse{}
+
+	code, err := c.doRequest(RequestArgs{
+		AuthToken:            token,
+		Method:               "LIST",
+		Path:                 oidcKeyAPI,
+		JSONObject:           nil,
+		BodyReader:           nil,
+		OperationDescription: "List Named Keys",
+		ExpectedStatusCode:   http.StatusOK,
+		ResponseObject:       &response,
+	})
+
+	// 404 is a valid response, either if there are no entities at all
+	// or if the one we are looking for isn't there
+
+	if code == http.StatusNotFound {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	for _, v := range response.Data.Keys {
+		if v == "keyName" {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (c *Client) CreateNamedIdentityKey(token string, keyName string, algorithm string) error {
+
+	request := CreateNamedKeyRequest{
+		AllowedClientIDs: []string{"*"},
+		Algorithm:        algorithm,
+	}
+
+	_, err := c.doRequest(RequestArgs{
+		AuthToken:            token,
+		Method:               http.MethodPost,
+		Path:                 path.Join(oidcKeyAPI, keyName),
+		JSONObject:           request,
+		BodyReader:           nil,
+		OperationDescription: "Create Named Key",
+		ExpectedStatusCode:   http.StatusNoContent,
+		ResponseObject:       nil,
+	})
+
+	return err
+}
+
+func (c *Client) CreateOrUpdateIdentityRole(token string, roleName string, keyName string, template string, jwtTTL string) error {
+
+	var templatePointer *string = nil
+	if template != "" {
+		templatePointer = &template
+	}
+
+	request := CreateOrUpdateIdentityRoleRequest{
+		Key:      keyName,
+		Template: templatePointer, // optional field
+		TokenTTL: jwtTTL,
+	}
+
+	_, err := c.doRequest(RequestArgs{
+		AuthToken:            token,
+		Method:               http.MethodPost,
+		Path:                 path.Join(oidcRoleAPI, roleName),
+		JSONObject:           request,
+		BodyReader:           nil,
+		OperationDescription: "Create OIDC JWT role",
+		ExpectedStatusCode:   http.StatusNoContent,
+		ResponseObject:       nil,
+	})
+
 	return err
 }

--- a/internal/pkg/vault/models.go
+++ b/internal/pkg/vault/models.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	KeyValue = "kv"
-	Consul   = "consul"
+	KeyValue                   = "kv"
+	Consul                     = "consul"
+	UsernamePasswordAuthMethod = "userpass"
 )
 
 // InitRequest contains a Vault init request regarding the Shamir Secret Sharing (SSS) parameters
@@ -74,7 +75,7 @@ type LookupAccessorRequest struct {
 	Accessor string `json:"accessor"`
 }
 
-// ListSecretEnginesResponse is the response to GET /v1/sys/mounts
+// ListSecretEnginesResponse is the response to GET /v1/sys/mounts (and /v1/sys/auth)
 type ListSecretEnginesResponse struct {
 	Data map[string]struct {
 		Type string `json:"type"`
@@ -110,4 +111,87 @@ type EnableSecretsEngineRequest struct {
 	Description string                `json:"description"`
 	Options     *SecretsEngineOptions `json:"options,omitempty"`
 	Config      *SecretsEngineConfig  `json:"config,omitempty"`
+}
+
+// CreateUpdateEntityRequest enables or updates a Vault Identity
+type CreateUpdateEntityRequest struct {
+	Metadata map[string]string `json:"metadata"`
+	Policies []string          `json:"policies"`
+}
+
+// JsonID
+type JsonID struct {
+	ID string `json:"id"`
+}
+
+// CreateUpdateEntityResponse is the response to CreateUpdateEntityRequest
+type CreateUpdateEntityResponse struct {
+	Data JsonID `json:"data"`
+}
+
+// ReadEntityByNameResponse is the response to get entity by name
+type ReadEntityByNameResponse struct {
+	Data JsonID `json:"data"`
+}
+
+// EnableAuthMethodRequest enables a Vault Identity authentication method
+type EnableAuthMethodRequest struct {
+	Type string `json:"type"`
+}
+
+// Accessor
+type Accessor struct {
+	Accessor string `json:"accessor"`
+}
+
+// ListAuthMethodsResponse is used to look up the accessor ID of an auth method
+type ListAuthMethodsResponse struct {
+	Data map[string]Accessor `json:"data"`
+}
+
+// CreateOrUpdateUserRequest is used to create a vault login
+type CreateOrUpdateUserRequest struct {
+	Password      string   `json:"password"`
+	TokenPeriod   string   `json:"token_period"`
+	TokenPolicies []string `json:"token_policies"`
+}
+
+// CreateOrUpdateUserResponse is the response to get entity by name
+type CreateOrUpdateUserResponse struct {
+	Data JsonID `json:"data"`
+}
+
+// CreateEntityAliasRequest is used to bind an authenticator to an identity
+type CreateEntityAliasRequest struct {
+	// Name is the username in the authenticator
+	Name string `json:"name"`
+	// CanonicalID is the entity ID
+	CanonicalID string `json:"canonical_id"`
+	// MountAccessor is the id if the auth engine to use
+	MountAccessor string `json:"mount_accessor"`
+}
+
+// UserPassLoginRequest is used to to log in an identity with the userpass auth engine
+type UserPassLoginRequest struct {
+	Password string `json:"password"`
+}
+
+// ListNamedKeysResponse is the response to LIST /v1/identity/oidc/key
+type ListNamedKeysResponse struct {
+	Data struct {
+		Keys []string `json:"keys"`
+	} `json:"data"`
+}
+
+// CreateNamedKeyRequest is the request to POST /v1/identity/oidc/key/:name:
+type CreateNamedKeyRequest struct {
+	AllowedClientIDs []string `json:"allowed_client_ids"`
+	Algorithm        string   `json:"algorithm"`
+}
+
+// CreateOrUpdateIdentityRoleRequest is the request to POST /v1/identity/oidc/role/:name
+type CreateOrUpdateIdentityRoleRequest struct {
+	Key      string  `json:"key"`
+	Template *string `json:"template,omitempty"`
+	TokenTTL string  `json:"ttl"`
 }

--- a/internal/pkg/vault/request.go
+++ b/internal/pkg/vault/request.go
@@ -82,7 +82,6 @@ func (c *Client) doRequest(params RequestArgs) (int, error) {
 
 	if resp.StatusCode != params.ExpectedStatusCode {
 		err := fmt.Errorf("request to %s failed with status: %s", params.OperationDescription, resp.Status)
-		c.lc.Error(err.Error())
 		return resp.StatusCode, err
 	}
 

--- a/pkg/listener/poll_test.go
+++ b/pkg/listener/poll_test.go
@@ -114,6 +114,14 @@ func (mssm MockSecretClient) SetAuthToken(_ context.Context, _ string) error {
 	panic("SetAuthToken not implemented")
 }
 
+func (mssm MockSecretClient) GetSelfJWT(_ string) (string, error) {
+	panic("GetSelfJWT not implemented")
+}
+
+func (mssm MockSecretClient) IsJWTValid(_ string) (bool, error) {
+	panic("IsJWTValid not implemented")
+}
+
 func TestGetKeys(t *testing.T) {
 	testClient := newTestMockSecretClient()
 	tests := []struct {

--- a/secrets/interfaces.go
+++ b/secrets/interfaces.go
@@ -52,6 +52,12 @@ type SecretClient interface {
 	// GetKeys retrieves the keys at the provided sub-path. Secret Store returns an array of keys for a given path when
 	// retrieving a list of keys, versus a k/v map when retrieving secrets.
 	GetKeys(subPath string) ([]string, error)
+
+	// GetSelfJWT returns an encoded JWT for the current identity-based secret store token
+	GetSelfJWT(serviceKey string) (string, error)
+
+	// IsJWTValid evaluates a given JWT and returns a true/false if the JWT is valid (i.e. belongs to us and current) or not
+	IsJWTValid(jwt string) (bool, error)
 }
 
 // SecretStoreClient provides a contract for managing a Secret Store from a secret store provider.
@@ -72,4 +78,17 @@ type SecretStoreClient interface {
 	RevokeToken(token string) error
 	ConfigureConsulAccess(secretStoreToken string, bootstrapACLToken string, consulHost string, consulPort int) error
 	CreateRole(secretStoreToken string, consulRole types.ConsulRole) error
+	CreateOrUpdateIdentity(token string, name string, metadata map[string]string, policies []string) (string, error)
+	DeleteIdentity(token string, name string) error
+	LookupIdentity(token string, name string) (string, error)
+	CheckAuthMethodEnabled(token string, mountPoint string, authType string) (bool, error)
+	EnablePasswordAuth(token string, mountPoint string) error
+	LookupAuthHandle(token string, mountPoint string) (string, error)
+	CreateOrUpdateUser(token string, mountPoint string, username string, password string, tokenTTL string, tokenPolicies []string) error
+	DeleteUser(token string, mountPoint string, username string) error
+	BindUserToIdentity(token string, identityId string, authHandle string, username string) error
+	InternalServiceLogin(token string, authEngine string, username string, password string) (map[string]interface{}, error)
+	CheckIdentityKeyExists(token string, keyName string) (bool, error)
+	CreateNamedIdentityKey(token string, keyName string, algorithm string) error
+	CreateOrUpdateIdentityRole(token string, roleName string, keyName string, template string, jwtTTL string) error
 }

--- a/secrets/mocks/SecretClient.go
+++ b/secrets/mocks/SecretClient.go
@@ -87,6 +87,48 @@ func (_m *SecretClient) GetSecrets(subPath string, keys ...string) (map[string]s
 	return r0, r1
 }
 
+// GetSelfJWT provides a mock function with given fields: serviceKey
+func (_m *SecretClient) GetSelfJWT(serviceKey string) (string, error) {
+	ret := _m.Called(serviceKey)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(serviceKey)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(serviceKey)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// IsJWTValid provides a mock function with given fields: jwt
+func (_m *SecretClient) IsJWTValid(jwt string) (bool, error) {
+	ret := _m.Called(jwt)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(jwt)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(jwt)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // SetAuthToken provides a mock function with given fields: ctx, token
 func (_m *SecretClient) SetAuthToken(ctx context.Context, token string) error {
 	ret := _m.Called(ctx, token)

--- a/secrets/mocks/SecretStoreClient.go
+++ b/secrets/mocks/SecretStoreClient.go
@@ -13,6 +13,62 @@ type SecretStoreClient struct {
 	mock.Mock
 }
 
+// BindUserToIdentity provides a mock function with given fields: token, identityId, authHandle, username
+func (_m *SecretStoreClient) BindUserToIdentity(token string, identityId string, authHandle string, username string) error {
+	ret := _m.Called(token, identityId, authHandle, username)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string, string, string) error); ok {
+		r0 = rf(token, identityId, authHandle, username)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// CheckAuthMethodEnabled provides a mock function with given fields: token, mountPoint, authType
+func (_m *SecretStoreClient) CheckAuthMethodEnabled(token string, mountPoint string, authType string) (bool, error) {
+	ret := _m.Called(token, mountPoint, authType)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string, string, string) bool); ok {
+		r0 = rf(token, mountPoint, authType)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = rf(token, mountPoint, authType)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// CheckIdentityKeyExists provides a mock function with given fields: token, keyName
+func (_m *SecretStoreClient) CheckIdentityKeyExists(token string, keyName string) (bool, error) {
+	ret := _m.Called(token, keyName)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string, string) bool); ok {
+		r0 = rf(token, keyName)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(token, keyName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // CheckSecretEngineInstalled provides a mock function with given fields: token, mountPoint, engine
 func (_m *SecretStoreClient) CheckSecretEngineInstalled(token string, mountPoint string, engine string) (bool, error) {
 	ret := _m.Called(token, mountPoint, engine)
@@ -41,6 +97,69 @@ func (_m *SecretStoreClient) ConfigureConsulAccess(secretStoreToken string, boot
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, string, string, int) error); ok {
 		r0 = rf(secretStoreToken, bootstrapACLToken, consulHost, consulPort)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// CreateNamedIdentityKey provides a mock function with given fields: token, keyName, algorithm
+func (_m *SecretStoreClient) CreateNamedIdentityKey(token string, keyName string, algorithm string) error {
+	ret := _m.Called(token, keyName, algorithm)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string, string) error); ok {
+		r0 = rf(token, keyName, algorithm)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// CreateOrUpdateIdentity provides a mock function with given fields: token, name, metadata, policies
+func (_m *SecretStoreClient) CreateOrUpdateIdentity(token string, name string, metadata map[string]string, policies []string) (string, error) {
+	ret := _m.Called(token, name, metadata, policies)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string, string, map[string]string, []string) string); ok {
+		r0 = rf(token, name, metadata, policies)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string, map[string]string, []string) error); ok {
+		r1 = rf(token, name, metadata, policies)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// CreateOrUpdateIdentityRole provides a mock function with given fields: token, roleName, keyName, template, jwtTTL
+func (_m *SecretStoreClient) CreateOrUpdateIdentityRole(token string, roleName string, keyName string, template string, jwtTTL string) error {
+	ret := _m.Called(token, roleName, keyName, template, jwtTTL)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string, string, string, string) error); ok {
+		r0 = rf(token, roleName, keyName, template, jwtTTL)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// CreateOrUpdateUser provides a mock function with given fields: token, mountPoint, username, password, tokenTTL, tokenPolicies
+func (_m *SecretStoreClient) CreateOrUpdateUser(token string, mountPoint string, username string, password string, tokenTTL string, tokenPolicies []string) error {
+	ret := _m.Called(token, mountPoint, username, password, tokenTTL, tokenPolicies)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string, string, string, string, []string) error); ok {
+		r0 = rf(token, mountPoint, username, password, tokenTTL, tokenPolicies)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -85,6 +204,34 @@ func (_m *SecretStoreClient) CreateToken(token string, parameters map[string]int
 	return r0, r1
 }
 
+// DeleteIdentity provides a mock function with given fields: token, name
+func (_m *SecretStoreClient) DeleteIdentity(token string, name string) error {
+	ret := _m.Called(token, name)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = rf(token, name)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DeleteUser provides a mock function with given fields: token, mountPoint, username
+func (_m *SecretStoreClient) DeleteUser(token string, mountPoint string, username string) error {
+	ret := _m.Called(token, mountPoint, username)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string, string) error); ok {
+		r0 = rf(token, mountPoint, username)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // EnableConsulSecretEngine provides a mock function with given fields: token, mountPoint, defaultLeaseTTL
 func (_m *SecretStoreClient) EnableConsulSecretEngine(token string, mountPoint string, defaultLeaseTTL string) error {
 	ret := _m.Called(token, mountPoint, defaultLeaseTTL)
@@ -106,6 +253,20 @@ func (_m *SecretStoreClient) EnableKVSecretEngine(token string, mountPoint strin
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, string, string) error); ok {
 		r0 = rf(token, mountPoint, kvVersion)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// EnablePasswordAuth provides a mock function with given fields: token, mountPoint
+func (_m *SecretStoreClient) EnablePasswordAuth(token string, mountPoint string) error {
+	ret := _m.Called(token, mountPoint)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = rf(token, mountPoint)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -169,6 +330,29 @@ func (_m *SecretStoreClient) InstallPolicy(token string, policyName string, poli
 	return r0
 }
 
+// InternalServiceLogin provides a mock function with given fields: token, authEngine, username, password
+func (_m *SecretStoreClient) InternalServiceLogin(token string, authEngine string, username string, password string) (map[string]interface{}, error) {
+	ret := _m.Called(token, authEngine, username, password)
+
+	var r0 map[string]interface{}
+	if rf, ok := ret.Get(0).(func(string, string, string, string) map[string]interface{}); ok {
+		r0 = rf(token, authEngine, username, password)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]interface{})
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string, string, string) error); ok {
+		r1 = rf(token, authEngine, username, password)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ListTokenAccessors provides a mock function with given fields: token
 func (_m *SecretStoreClient) ListTokenAccessors(token string) ([]string, error) {
 	ret := _m.Called(token)
@@ -185,6 +369,48 @@ func (_m *SecretStoreClient) ListTokenAccessors(token string) ([]string, error) 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(string) error); ok {
 		r1 = rf(token)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// LookupAuthHandle provides a mock function with given fields: token, mountPoint
+func (_m *SecretStoreClient) LookupAuthHandle(token string, mountPoint string) (string, error) {
+	ret := _m.Called(token, mountPoint)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string, string) string); ok {
+		r0 = rf(token, mountPoint)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(token, mountPoint)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// LookupIdentity provides a mock function with given fields: token, name
+func (_m *SecretStoreClient) LookupIdentity(token string, name string) (string, error) {
+	ret := _m.Called(token, name)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string, string) string); ok {
+		r0 = rf(token, name)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(token, name)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
This set of changes enables secret store tokens to be identity-based.
Instead of issuing anonymous Vault tokens with attached policy,
this commit adds additional methods to create Vault-based
identities and authenticate to these identities using
programmable auth methods. This is important step to "deprivilege"
Vault usage, as creating raw tokens requires "sudo" ability in Vault,
whereas identity auth is a user operation. Additionally,
vault-based identity can be attested (as a JWT) and verified.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-secrets/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [X] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->