### PR TITLE
fix!: Missed /v3 change prior to EdgeX 3.0 code freeze

### DIFF
--- a/pkg/constants.go
+++ b/pkg/constants.go
@@ -14,11 +14,15 @@
 
 package pkg
 
+import (
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
+)
+
 // Defines the valid secret store providers.
 const (
 	CoreSecurityServiceKey         = "edgex-core-security"
 	ConfigFileName                 = "configuration.toml"
 	ConfigDirectory                = "./res"
 	ConfigDirEnv                   = "EDGEX_CONF_DIR"
-	SpiffeTokenProviderGetTokenAPI = "/api/v2/gettoken" // nolint: gosec
+	SpiffeTokenProviderGetTokenAPI = common.ApiBase + "/gettoken" // nolint: gosec
 )


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
Late-change due to regression failure. 
Git psudoversion for testing is github.com/bnevis-i/go-mod-secrets v3.0.0-20230524152540-f3ad386fe291

Tested override in device-virtual and edgex-go, and this seems to resolve the issue.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->