### PR TITLE
fix(security): Allow underscores in service keys / Vault usernames

### DIFF
--- a/internal/pkg/vault/management.go
+++ b/internal/pkg/vault/management.go
@@ -398,7 +398,7 @@ func (c *Client) LookupAuthHandle(token string, mountPoint string) (string, erro
 
 func (c *Client) CreateOrUpdateUser(token string, mountPoint string, username string, password string, tokenTTL string, tokenPolicies []string) error {
 
-	const UserNameRE string = "^[-a-zA-Z0-9]+$"
+	const UserNameRE string = "^[-a-zA-Z0-9_]+$"
 
 	re, err := regexp.Compile(UserNameRE)
 	if err != nil {
@@ -432,7 +432,7 @@ func (c *Client) CreateOrUpdateUser(token string, mountPoint string, username st
 
 func (c *Client) DeleteUser(token string, mountPoint string, username string) error {
 
-	const UserNameRE string = "^[-a-zA-Z0-9]+$"
+	const UserNameRE string = "^[-a-zA-Z0-9_]+$"
 
 	re, err := regexp.Compile(UserNameRE)
 	if err != nil {


### PR DESCRIPTION
Closes edgex-go#4621

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
See testing instructions in https://github.com/edgexfoundry/edgex-go/issues/4621.  Basically, create a service key with _1, _2, etc at the end.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->